### PR TITLE
Implement UPSTREAM tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ If you want to be notified in Slack about the status of recent rebases, you can 
 ...
 ```
 
+### Tag policy
+
+This option allows to manage UPSTREAM commit message tags policy.
+
+- `--tag-policy=none` will take all commits into the rebase PR, regardless of their tags, even including `UPSTREAM: <drop>`.
+
+- `--tag-policy=soft` if the commit has `UPSTREAM: <something>` it will be taken into account, otherwise we keep it.
+
+- `--tag-policy=strict` is similar to the previous one, but it discards commits without "UPSTREAM:" tags.
+
+Default value is `none`.
+
 ### Custom git username and email
 
 By default the bot takes global git username and email to perform the rebase. If you want to change it to something else you can use `--git-username` and `--git-email` options.

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -105,7 +105,31 @@ def _needs_rebase(gitwd, source, dest):
     return True
 
 
-def _do_rebase(gitwd, source, dest):
+def _is_pr_merged(pr_number, source_repo):
+    logging.info("Checking that PR %s has been merged", pr_number)
+    gh_pr = source_repo.pull_request(pr_number)
+    return gh_pr.is_merged()
+
+
+def _add_to_rebase(commit_message, source_repo):
+    if commit_message.startswith("UPSTREAM: "):
+        commit_message = commit_message.removeprefix("UPSTREAM: ")
+        commit_tag = commit_message.split(":", 1)[0]
+        if commit_tag == "<drop>":
+            return False
+
+        if commit_tag == "<carry>":
+            return True
+
+        if commit_tag.isnumeric():
+            return not _is_pr_merged(int(commit_tag), source_repo)
+
+        raise Exception(f"Unknown commit message tag: {commit_tag}")
+
+    return True
+
+
+def _do_rebase(gitwd, source, dest, source_repo):
     logging.info("Performing rebase")
 
     merge_base = gitwd.git.merge_base(f"source/{source.branch}", f"dest/{dest.branch}")
@@ -120,7 +144,11 @@ def _do_rebase(gitwd, source, dest):
     for commit in commits.splitlines():
         # Commit contains the message for logging purposes,
         # trim on the first space to get just the commit sha
-        sha = commit.split(" ", 1)[0]
+        sha, commit_message = commit.split(" - ")
+
+        if not _add_to_rebase(commit_message, source_repo):
+            continue
+
         try:
             gitwd.git.cherry_pick(f"{sha}", "-Xtheirs")
         except git.GitCommandError as ex:
@@ -425,6 +453,8 @@ def run(
         logging.info("Destination repository is %s", dest_repo.clone_url)
         rebase_repo = gh_cloner_app.repository(rebase.ns, rebase.name)
         logging.info("rebase repository is %s", rebase_repo.clone_url)
+        source_repo = gh_app.repository(source.ns, source.name)
+        logging.info("source repository is %s", source_repo.clone_url)
     except Exception as ex:
         logging.exception(ex)
         _message_slack(
@@ -459,7 +489,7 @@ def run(
     try:
         needs_rebase = _needs_rebase(gitwd, source, dest)
         if needs_rebase:
-            _do_rebase(gitwd, source, dest)
+            _do_rebase(gitwd, source, dest, source_repo)
 
             if update_go_modules:
                 _commit_go_mod_updates(gitwd, source)

--- a/rebasebot/cli.py
+++ b/rebasebot/cli.py
@@ -20,13 +20,11 @@ import argparse
 from collections import namedtuple
 import re
 import sys
-import validators
 
 from rebasebot import bot
 
 
 GitHubBranch = namedtuple("GitHubBranch", ["url", "ns", "name", "branch"])
-GitBranch = namedtuple("GitBranch", ["url", "branch"])
 
 
 class GitHubBranchAction(argparse.Action):
@@ -40,6 +38,9 @@ class GitHubBranchAction(argparse.Action):
     GITHUBBRANCH = re.compile("^(?P<ns>[^/]+)/(?P<name>[^:]+):(?P<branch>.*)$")
 
     def __call__(self, parser, namespace, values, option_string=None):
+        # For backward compatibility we need to ensure that the prefix was removed
+        values = values.removeprefix("https://github.com/")
+
         match = self.GITHUBBRANCH.match(values)
         if match is None:
             parser.error(
@@ -59,31 +60,6 @@ class GitHubBranchAction(argparse.Action):
         )
 
 
-class GitBranchAction(argparse.Action):
-    """An action to take a git branch argument in the form:
-
-      <git url>:<branch>
-
-    The argument will be return as a GitBranch object.
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        msg = (
-            f"Git branch value for {option_string} must be in "
-            f"the form <git url>:<branch>"
-        )
-
-        split = values.rsplit(":", 1)
-        if len(split) != 2:
-            parser.error(msg)
-
-        url, branch = split
-        if not validators.url(url):
-            parser.error(msg)
-
-        setattr(namespace, self.dest, GitBranch(url, branch))
-
-
 # parse_cli_arguments parses command line arguments using argparse and returns
 # an object representing the populated namespace, and a list of errors
 #
@@ -101,7 +77,7 @@ def _parse_cli_arguments(testing_args=None):
         "-s",
         type=str,
         required=True,
-        action=GitBranchAction,
+        action=GitHubBranchAction,
         help=(
             "The source/upstream git repo to rebase changes onto in the form "
             "<git url>:<branch>. Note that unlike dest and rebase this does "

--- a/rebasebot/cli.py
+++ b/rebasebot/cli.py
@@ -173,6 +173,14 @@ def _parse_cli_arguments(testing_args=None):
         required=False,
         help="When enabled, the bot will not create a PR.",
     )
+    parser.add_argument(
+        "--tag-policy",
+        default="none",
+        const="none",
+        nargs="?",
+        choices=["none", "soft", "strict"],
+        help="Option that shows how to handle UPSTREAM tags in "
+             "commit messages. (default: %(default)s)")
 
     if testing_args is not None:
         args = parser.parse_args(testing_args)
@@ -219,6 +227,7 @@ def main():
         args.github_cloner_id,
         gh_cloner_key,
         slack_webhook,
+        args.tag_policy,
         update_go_modules=args.update_go_modules,
         dry_run=args.dry_run,
     )

--- a/rebasebot/test.py
+++ b/rebasebot/test.py
@@ -154,20 +154,30 @@ class test_go_mod(unittest.TestCase):
 
     @patch('rebasebot.bot._is_pr_merged')
     def test_commit_tags(self, mocked_is_pr_merged):
-        self.assertTrue(bot._add_to_rebase("UPSTREAM: <carry>: something", None))
+        self.assertTrue(bot._add_to_rebase("UPSTREAM: <carry>: something", None, "soft"))
 
-        self.assertFalse(bot._add_to_rebase("UPSTREAM: <drop>: something", None))
+        self.assertFalse(bot._add_to_rebase("UPSTREAM: <drop>: something", None, "soft"))
 
         mocked_is_pr_merged.return_value = True
-        self.assertFalse(bot._add_to_rebase("UPSTREAM: 100: something", None))
+        self.assertFalse(bot._add_to_rebase("UPSTREAM: 100: something", None, "soft"))
 
         mocked_is_pr_merged.return_value = False
-        self.assertTrue(bot._add_to_rebase("UPSTREAM: 100: something", None))
+        self.assertTrue(bot._add_to_rebase("UPSTREAM: 100: something", None, "soft"))
 
         self.assertRaises(Exception, bot._add_to_rebase, "UPSTREAM: INVALID: something", None)
 
-        self.assertTrue(bot._add_to_rebase("No Tag: <carry>: something", None))
-        self.assertTrue(bot._add_to_rebase("No Tag: something", None))
+        self.assertTrue(bot._add_to_rebase("No Tag: <carry>: something", None, "soft"))
+        self.assertTrue(bot._add_to_rebase("No Tag: something", None, "soft"))
+
+        # With "strict" tag policy intagged commits are discarded
+        self.assertFalse(bot._add_to_rebase("No Tag: <carry>: something", None, "strict"))
+        self.assertFalse(bot._add_to_rebase("No Tag: something", None, "strict"))
+
+        # We always keep commits with "none" tag policy
+        self.assertTrue(bot._add_to_rebase("UPSTREAM: <drop>: something", None, "none"))
+
+        mocked_is_pr_merged.return_value = True
+        self.assertTrue(bot._add_to_rebase("UPSTREAM: 100: something", None, "none"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit allows the bot to react on UPSTREAM tags in commit
messages accordingly:

- UPSTREAM: <carry>: the commit will be taken
- UPSTREAM: <drop>: the commit will be omitted
- UPSTREAM: PR_ID: if PR with id PR_ID is merged, it will be ignored   otherwise taken into the rebase PR.