### PR TITLE
Add compat mode for "go mod tidy"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 
 USER root
 
-ENV GO_VERSION=1.17.2
+ENV GO_VERSION=1.17.8
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf - go/bin go/pkg/linux_amd64 go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -63,7 +63,7 @@ def _commit_go_mod_updates(gitwd, source):
             gitwd.remotes.source.repo.git.checkout(f"source/{source.branch}", filename)
 
         proc = subprocess.run(
-            "go mod tidy", shell=True, check=True, capture_output=True
+            "go mod tidy -compat=1.17", shell=True, check=True, capture_output=True
         )
         logging.debug("go mod tidy output: %s", proc.stdout.decode())
         proc = subprocess.run(


### PR DESCRIPTION
To prevent errors like

```txt
ERROR - Unable to update go modules: Command 'go mod tidy' returned non-zero exit status 1.: go mod tidy: error loading go 1.16 module graph
```

we need to enable "compat" mode there.