### PR TITLE
Bump golang version to 1.18

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 
 USER root
 
-ENV GO_VERSION=1.17.2
+ENV GO_VERSION=1.18
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf - go/bin go/pkg/linux_amd64 go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"


### PR DESCRIPTION
Now some repos require golang 1.18, so `go mod tidy` fails on them.
This commit starts using golang 1.18 for updating repos modules.