### PR TITLE
Update container to support Go 1.19 and UBI9

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi9/python-39
 
 USER root
 
-ENV GO_VERSION=1.18
+ENV GO_VERSION=1.19
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf - go/bin go/pkg/linux_amd64 go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"


### PR DESCRIPTION
We have a number of repositories with a minimum version of 1.19 now, so we need to bump Go.
Tested locally by building the container.