### PR TITLE
[OCPCLOUD-1762]: Update rebasebot to create fresh Go mod updates

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -157,7 +157,9 @@ def _do_rebase(gitwd, source, dest, source_repo, tag_policy, update_go_modules):
         if update_go_modules:
             # If we find a commit with such name, we know that it is a go mod update commit
             # and append such commit to a list of commits that we want to prune
-            if commit_message == "UPSTREAM: <carry>: Updating and vendoring go modules after an upstream rebase":
+            if commit_message == "UPSTREAM: <carry>: Updating and vendoring " + \
+                                 "go modules after an upstream rebase":
+                logging.info("Dropping Go modules commit %s - %s", sha, commit_message)
                 continue
 
         if not _add_to_rebase(commit_message, source_repo, tag_policy):

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -157,8 +157,11 @@ def _do_rebase(gitwd, source, dest, source_repo, tag_policy, update_go_modules):
         sha, commit_message = commit.split(" - ")
 
         if update_go_modules:
+            # If we find a commit with such name, we know that it is a go mod update commit
+            # We then replace <carry> flag for <drop> flag
+            # and append such commit to a list of commits that we want to prune
             if commit_message.find("UPSTREAM: <carry>: Updating and vendoring go modules "
-                "after an upstream rebase"):
+                                   "after an upstream rebase"):
                 commit_message.replace("<carry>", "<drop>")
                 go_mod_commits.append(sha)
 
@@ -179,7 +182,7 @@ def _do_rebase(gitwd, source, dest, source_repo, tag_policy, update_go_modules):
             gitwd.git.cherry_pick(f"{sha}", "-Xtheirs")
         gitwd.git.reset("--hard", f"HEAD~{len(go_mod_commits)}")
         gitwd.git.commit("-m", "UPSTREAM: <carry>: Updating and vendoring go modules "
-                "after an upstream rebase")
+                         "after an upstream rebase")
 
 
 def _prepare_rebase_branch(gitwd, source, dest):


### PR DESCRIPTION
This PR add the ability for the rebasebot to delete old commits of go mod updates and create a new one and only commit regarding these changes.