### PR TITLE
OCPCLOUD-1786: Allow to exclude commits from rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ By default the bot takes global git username and email to perform the rebase. If
 ...
 ```
 
+### Excplicitly excluding some commits from rebase
+
+If for some reason you don't want to include some commits in your rebase PR, you can explicitly do it with `--exclude-commits` option that specifies a list of excluded commit hash prefixes.
+
+```txt
+...
+--exclude-commits b359659 4a89f92 5f4130e \
+...
+```
+
 ## Examples of usage
 
 Example 1. Sync kubernetes/cloud-provider-aws with openshift/cloud-provider-aws using applications credentials. 

--- a/rebasebot/cli.py
+++ b/rebasebot/cli.py
@@ -186,7 +186,7 @@ def _parse_cli_arguments(testing_args=None):
         action="store_true",
         default=False,
         required=False,
-        help="When enabled, the bot will be able to squash some"
+        help="When enabled, the bot will be able to squash some "
              "bot's commits - provided a list of bot emails.",
     )
     parser.add_argument(
@@ -195,6 +195,13 @@ def _parse_cli_arguments(testing_args=None):
         nargs="+",
         required=False,
         help="Specify the bot emails to be able to squash their commits.",
+    )
+    parser.add_argument(
+        "--exclude-commits",
+        type=str,
+        nargs="+",
+        required=False,
+        help="List of commit sha hashes that will be excluded from rebase.",
     )
 
     if testing_args is not None:
@@ -245,6 +252,7 @@ def main():
         args.tag_policy,
         args.allow_bot_squash,
         args.bot_emails,
+        args.exclude_commits,
         update_go_modules=args.update_go_modules,
         dry_run=args.dry_run,
     )

--- a/rebasebot/test.py
+++ b/rebasebot/test.py
@@ -98,7 +98,7 @@ class test_go_mod(unittest.TestCase):
         repo.git.add(all=True)
         repo.git.commit("-m", "Initial commit")
 
-        source = cli.GitHubBranch(tmp_dir, "example", "foo", "master")
+        source = cli.GitHubBranch(tmp_dir, "example", "foo", "main")
         repo.create_remote("source", source.url)
         repo.remotes.source.fetch(source.branch)
 
@@ -135,7 +135,7 @@ class test_go_mod(unittest.TestCase):
         repo.git.add(all=True)
         repo.git.commit("-m", "Initial commit")
 
-        source = cli.GitHubBranch(tmp_dir, "example", "foo", "master")
+        source = cli.GitHubBranch(tmp_dir, "example", "foo", "main")
         repo.create_remote("source", source.url)
         repo.remotes.source.fetch(source.branch)
 


### PR DESCRIPTION
This commit adds an option to explicitly exclude some commits from resulting rebase PR.

Example:
`rebasebot ... --exclude-commits sha1 sha2 sha3 ...`