### PR TITLE
Set empty tuple as a default for emails and commits arg

### DIFF
--- a/rebasebot/cli.py
+++ b/rebasebot/cli.py
@@ -192,6 +192,7 @@ def _parse_cli_arguments(testing_args=None):
     parser.add_argument(
         "--bot-emails",
         type=str,
+        default=(),
         nargs="+",
         required=False,
         help="Specify the bot emails to be able to squash their commits.",
@@ -199,6 +200,7 @@ def _parse_cli_arguments(testing_args=None):
     parser.add_argument(
         "--exclude-commits",
         type=str,
+        default=(),
         nargs="+",
         required=False,
         help="List of commit sha hashes that will be excluded from rebase.",


### PR DESCRIPTION
By default if no arg is provided there would be `None`, which causes crashes down the line

Quick fix for the https://github.com/openshift-eng/rebasebot/pull/21 which I rushy tagged without checking this beforehand.

Tested manually, just checked default value in debugger.