### PR TITLE
Fix git credentials

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -387,7 +387,7 @@ def _init_working_dir(
             config.set_value(
                 f'credential "{repo}"',
                 "helper",
-                f'"!f() {{ echo "password=$(cat {credentials})"; }}; f"',
+                f'"!f() {{ echo "password={credentials}"; }}; f"',
             )
 
             if git_email != "":


### PR DESCRIPTION
Before "credentials" was a file path, like "/dev/shm/credentials/app", and we exported the data using "cat" command.

But now it is a real auth token, so we don't need to "cat" anymore.