### PR TITLE
OCPCLOUD-1796: Helper repo init fixtures, initial tests

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -363,8 +363,9 @@ def _init_working_dir(
     github_app_provider: GithubAppProvider,
     git_username,
     git_email,
-):
-    gitwd = git.Repo.init(path=".")
+    workdir: str = "."
+) -> git.Repo:
+    gitwd = git.Repo.init(path=workdir)
 
     for remote, url in [
         ("source", source.url),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,6 @@ def init_test_repositories() -> YieldFixture[Tuple[GitHubBranch, GitHubBranch, G
 
 
 @pytest.fixture
-def fake_github_provider() -> YieldFixture[mock.MagicMock]:
+def fake_github_provider() -> mock.MagicMock:
     provider = mock.MagicMock(spec=GithubAppProvider)
     return provider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,19 @@
 import os
+import shutil
+from typing import Tuple, Generator, TypeVar
 from tempfile import TemporaryDirectory
 
 import pytest
+from unittest import mock
 
-from git import Repo
+from git import Repo, GitCommandError
 
+from rebasebot.github import GitHubBranch, GithubAppProvider
+
+
+T = TypeVar("T")
+
+YieldFixture = Generator[T, None, None]
 
 _GO_CODE = """
 package main
@@ -18,11 +27,16 @@ func main() {
 }
 """
 
+_ANOTHER_GO_CODE = """
+package main
+func foo() {}
+"""
+
 _GO_CODE_FILENAME = "test.go"
 
 
 @pytest.fixture
-def tmp_go_app_repo():
+def tmp_go_app_repo() -> YieldFixture[Tuple[str, Repo]]:
     with TemporaryDirectory(prefix="rebasebot_tests_") as tmpdir:
         with open(os.path.join(tmpdir, _GO_CODE_FILENAME), "x", encoding="utf8") as file:
             file.write(_GO_CODE)
@@ -33,3 +47,64 @@ def tmp_go_app_repo():
         repo.git.add(all=True)
         repo.git.commit("-m", "Initial commit")
         yield tmpdir, repo
+
+
+@pytest.fixture
+def tmpdir() -> YieldFixture[str]:
+    with TemporaryDirectory(prefix="rebasebot_tests_") as tmpdir:
+        yield tmpdir
+
+
+def commit_file_with_content(content: str, filename: str, commit_msg: str, gh_branch: GitHubBranch) -> None:
+    repo_path = gh_branch.url  # in this tests we are using temp dir as git remote
+    if not os.path.exists(repo_path):
+        raise NotADirectoryError("temp repo does not exists")
+    with open(os.path.join(repo_path, filename), "x", encoding="utf8") as file:
+        file.write(content)
+    repo = Repo.init(repo_path)
+    with repo.config_writer() as config:
+        config.set_value("user", "email", f"{gh_branch.name}_author@{gh_branch.ns}.org")
+        config.set_value("user", "name", f"{gh_branch.name}_author")
+    try:
+        repo.git.checkout(gh_branch.branch)
+    except GitCommandError:
+        repo.git.checkout("-b", gh_branch.branch)
+    repo.git.add(filename)
+    repo.git.commit("-m", commit_msg)
+
+
+@pytest.fixture
+def init_test_repositories() -> YieldFixture[Tuple[GitHubBranch, GitHubBranch, GitHubBranch]]:
+    """
+    Creates three repositories in own temp directories
+
+    source:
+     Represents upstream git repository. Contains one commit in 'main'
+    """
+
+    source = TemporaryDirectory(prefix="rebasebot_tests_source_repo_")
+    source_gh_branch = GitHubBranch(url=source.name, ns="source", name="source", branch="main")
+    commit_file_with_content(_GO_CODE, _GO_CODE_FILENAME, "Upstream commit", source_gh_branch)
+
+    rebase = TemporaryDirectory(prefix="rebasebot_tests_rebase_repo_")
+    rebase_repo = Repo.init(rebase.name)
+    rebase_gh_branch = GitHubBranch(url=rebase.name, ns="rebase", name="rebase", branch=rebase_repo.head.ref.name)
+
+    dest = TemporaryDirectory(prefix="rebasebot_tests_dest_repo_")
+    shutil.copytree(source.name, dest.name, dirs_exist_ok=True)
+    dest_gh_branch = GitHubBranch(url=dest.name, ns="dest", name="dest", branch="main")
+    commit_file_with_content(
+        _ANOTHER_GO_CODE, "another_file.go", "UPSTREAM: <carry>: our cool addition", dest_gh_branch
+    )
+
+    yield source_gh_branch, rebase_gh_branch, dest_gh_branch
+
+    source.cleanup()
+    rebase.cleanup()
+    dest.cleanup()
+
+
+@pytest.fixture
+def fake_github_provider() -> YieldFixture[mock.MagicMock]:
+    provider = mock.MagicMock(spec=GithubAppProvider)
+    return provider

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass
+import os
+
+import pytest
+
+from git import Repo
+
+from rebasebot.github import GitHubBranch
+from rebasebot.bot import (
+    _init_working_dir,
+    _needs_rebase,
+    _prepare_rebase_branch,
+
+    run as rebasebot_run
+)
+
+from .conftest import commit_file_with_content
+
+
+@dataclass
+class WorkingRepoContext:
+    source: GitHubBranch
+    rebase: GitHubBranch
+    dest: GitHubBranch
+
+    working_repo: Repo
+    working_repo_path: str
+
+    def fetch_remotes(self):
+        self.working_repo.git.fetch("--all")
+
+
+class TestBotInternalHelpers:
+
+    @pytest.fixture
+    def working_repo_context(self, init_test_repositories, fake_github_provider, tmpdir) -> WorkingRepoContext:
+        source, rebase, dest = init_test_repositories
+        working_repo = _init_working_dir(
+            source, dest, rebase, fake_github_provider, "foo", "foo@example.com", workdir=tmpdir
+        )
+        return WorkingRepoContext(
+            source, rebase, dest, working_repo, tmpdir
+        )
+
+    def test_workdir_init(self, working_repo_context):
+        working_repo = working_repo_context.working_repo
+        working_repo_path = working_repo_context.working_repo_path
+
+        assert working_repo
+        assert len(working_repo.remotes)
+        assert working_repo.working_dir == working_repo_path
+
+        commits = list(working_repo.iter_commits())
+        assert len(commits) == 1
+        assert commits[0].message == "Upstream commit\n"
+
+        working_repo_dir_content = [i.name for i in os.scandir(working_repo_path)]
+        assert working_repo_dir_content == ['test.go', '.git']
+
+    def test_needs_rebase(self, working_repo_context):
+        r_ctx = working_repo_context
+        gitwd, source, dest = r_ctx.working_repo, r_ctx.source, r_ctx.dest
+        assert not _needs_rebase(gitwd, source, dest)
+
+        commit_file_with_content("foo", "bar.txt", "UPSTREAM: <carry>: carry patch", dest)
+        working_repo_context.fetch_remotes()
+        assert not _needs_rebase(gitwd, source, dest)
+
+        commit_file_with_content("fiz", "baz.txt", "some other upstream commit", source)
+        working_repo_context.fetch_remotes()
+        assert _needs_rebase(gitwd, source, dest)
+
+    def test_prepare_rebase_branch(self, working_repo_context):
+        r_ctx = working_repo_context
+        _prepare_rebase_branch(r_ctx.working_repo, r_ctx.source, r_ctx.dest)
+
+        commits = list(r_ctx.working_repo.iter_commits())
+        assert len(commits[0].parents)
+        commit_msgs = [c.summary for c in commits]
+        assert commit_msgs == [
+            'merge upstream/main into main',  # merge commit
+            'UPSTREAM: <carry>: our cool addition',
+            'Upstream commit'
+        ]
+
+
+class TestRebases:
+
+    def test_simple_dry_run(self, init_test_repositories, fake_github_provider, tmpdir):
+        source, rebase, dest = init_test_repositories
+        commit_file_with_content("fiz", "baz.txt", "other upstream commit", source)
+
+        result = rebasebot_run(
+            source=source,
+            dest=dest,
+            rebase=rebase,
+            working_dir=tmpdir,
+            git_username="test_rebasebot",
+            git_email="test@rebasebot.ocp",
+            github_app_provider=fake_github_provider,
+            slack_webhook=None,
+            tag_policy="soft",
+            bot_emails=[],
+            exclude_commits=[],
+            update_go_modules=False,
+            dry_run=True,
+        )
+        assert result
+
+        working_repo = Repo.init(tmpdir)
+        assert working_repo.head.ref.name == "rebase"
+        log_graph = working_repo.git.log("--graph", "--oneline", "--pretty='<%an>, %s'")
+        assert log_graph == """ 
+* '<dest_author>, UPSTREAM: <carry>: our cool addition'
+*   '<test_rebasebot>, merge upstream/main into main'
+|\\  
+| * '<source_author>, other upstream commit'
+* | '<dest_author>, UPSTREAM: <carry>: our cool addition'
+|/  
+* '<source_author>, Upstream commit'
+""".strip()  # noqa: W291

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -54,8 +54,8 @@ class TestBotInternalHelpers:
         assert len(commits) == 1
         assert commits[0].message == "Upstream commit\n"
 
-        working_repo_dir_content = [i.name for i in os.scandir(working_repo_path)]
-        assert working_repo_dir_content == ['test.go', '.git']
+        working_repo_dir_content = {i.name for i in os.scandir(working_repo_path)}
+        assert working_repo_dir_content == {'test.go', '.git'}
 
     def test_needs_rebase(self, working_repo_context):
         r_ctx = working_repo_context


### PR DESCRIPTION
This PR adds some fixtures and a happy-path rebase bot tests using these fixtures.

More tests would be added here or in follow-ups. This might be merged anytime as far as ci passes.