### PR TITLE
Recursively find go.mod and run mod commands

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -81,10 +81,13 @@ def _commit_go_mod_updates(gitwd: git.Repo, source: GitHubBranch) -> None:
                 "go mod tidy", cwd=module_base_path, shell=True, check=True, capture_output=True
             )
             logging.debug("go mod tidy output: %s", proc.stdout.decode())
-            proc = subprocess.run(
-                "go mod vendor", cwd=module_base_path, shell=True, check=True, capture_output=True
-            )
-            logging.debug("go mod vendor output %s:", proc.stdout.decode())
+
+            # Only run go mod vendor if a vendor folder already exists
+            if os.path.exists(os.path.join(module_base_path, "vendor")):
+                proc = subprocess.run(
+                    "go mod vendor", cwd=module_base_path, shell=True, check=True, capture_output=True
+                )
+                logging.debug("go mod vendor output %s:", proc.stdout.decode())
 
         except subprocess.CalledProcessError as err:
             raise RepoException(


### PR DESCRIPTION
This extends the current `go mod tidy && go mod vendor` logic to recursively do so in other go submodules that might be present in the repository.

The go vendoring guarantees that no dependency `go.mod` files are present in the `./vendor` folder.

Successfully tried on: https://github.com/openshift/cluster-api-provider-ibmcloud/pull/48
For `./go.mod` and `./hack/tools/go.mod` in https://github.com/openshift/cluster-api-provider-ibmcloud/pull/48/commits/67dffdc9bafe1cef378338402683a8c3991ab356