### PR TITLE
Update container to go 1.20

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,9 +2,9 @@ FROM registry.access.redhat.com/ubi9/python-39
 
 USER root
 
-ENV GO_VERSION=1.19
+ENV GO_VERSION=1.20.3
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
-    tar -C /usr/local -zxvf - go/bin go/pkg/linux_amd64 go/pkg/tool
+    tar -C /usr/local -zxvf - go/bin go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"
 
 WORKDIR /src


### PR DESCRIPTION
Some repositories are already using go 1.20 and rebasebot is failing because of that. This PR updates the container to use go 1.20.3. Tested by building the container. 

go/pkg/linux_amd64 is removed because go 1.20 no longer ships libraries in binary form.