### PR TITLE
Smarter PR title updating

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -200,6 +200,7 @@ class TestUpdatePrTitle:
         gitwd = MagicMock()
         gitwd.git.rev_parse.return_value = "abcdefg"
         pull_req = MagicMock()
+        pull_req.title = "Merge https://github.com/kubernetes/cloud-provider-aws:master (b80e8ef) into master"
         pull_req.update.return_value = True
         source = MagicMock(branch="my-feature",
                            url="https://github.com/my/repo")
@@ -214,10 +215,48 @@ class TestUpdatePrTitle:
             title=f"Merge {source.url}:{source.branch} (abcdefg) into {dest.branch}"
         )
 
+    def test_jira_link(self):
+        gitwd = MagicMock()
+        gitwd.git.rev_parse.return_value = "abcdefg"
+        pull_req = MagicMock()
+        pull_req.title = "OCPCLOUD-2051: Merge "
+        "https://github.com/kubernetes/cloud-provider-aws:master (b80e8ef) into master"
+        pull_req.update.return_value = True
+        source = MagicMock(branch="my-feature",
+                           url="https://github.com/my/repo")
+        dest = MagicMock(branch="main")
+
+        try:
+            _update_pr_title(gitwd, pull_req, source, dest)
+        except Exception as ex:
+            assert False, f"Unexpected exception: {ex}"
+
+        pull_req.update.assert_called_once_with(
+            title=f"OCPCLOUD-2051: Merge {source.url}:{source.branch} (abcdefg) into {dest.branch}"
+        )
+
+    def test_unknown_format_keep_unchanged(self):
+        gitwd = MagicMock()
+        gitwd.git.rev_parse.return_value = "abcdefg"
+        pull_req = MagicMock()
+        pull_req.title = "OCPCLOUD-2051: Manual rebase to lastest upstream version"
+        pull_req.update.return_value = True
+        source = MagicMock(branch="my-feature",
+                           url="https://github.com/my/repo")
+        dest = MagicMock(branch="main")
+
+        try:
+            _update_pr_title(gitwd, pull_req, source, dest)
+        except Exception as ex:
+            assert False, f"Unexpected exception: {ex}"
+
+        pull_req.update.assert_not_called()
+
     def test_failure(self):
         gitwd = MagicMock()
         gitwd.git.rev_parse.return_value = "abcdefg"
         pull_req = MagicMock()
+        pull_req.title = "Merge https://github.com/kubernetes/cloud-provider-aws:master (b80e8ef) into master"
         pull_req.update.return_value = False
         source = MagicMock(branch="my-feature",
                            url="https://github.com/my/repo")


### PR DESCRIPTION
Introduces additional logic to updating already open pull requests titles. It now looks for the word "Merge" in the title. If it is found, it keeps everything before it and replaces everything after. This fixes UX issue of JIRA links tags being removed when the PR is updated.