### PR TITLE
Fixes around vendoring

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -83,12 +83,10 @@ def _commit_go_mod_updates(gitwd: git.Repo, source: GitHubBranch) -> None:
             )
             logging.debug("go mod tidy output: %s", proc.stdout.decode())
 
-            # Only run go mod vendor if a vendor folder already exists
-            if os.path.exists(os.path.join(module_base_path, "vendor")):
-                proc = subprocess.run(
-                    "go mod vendor", cwd=module_base_path, shell=True, check=True, capture_output=True
-                )
-                logging.debug("go mod vendor output %s:", proc.stdout.decode())
+            proc = subprocess.run(
+                "go mod vendor", cwd=module_base_path, shell=True, check=True, capture_output=True
+            )
+            logging.debug("go mod vendor output %s:", proc.stdout.decode())
 
         except subprocess.CalledProcessError as err:
             raise RepoException(

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -93,7 +93,7 @@ def _commit_go_mod_updates(gitwd: git.Repo, source: GitHubBranch) -> None:
                 f"Unable to update go modules: {err}: {err.stderr.decode()}"
             ) from err
 
-    if gitwd.is_dirty():
+    if gitwd.is_dirty(untracked_files=True):
         try:
             gitwd.git.add(all=True)
             gitwd.git.commit(


### PR DESCRIPTION
- [always run go mod vendor](https://github.com/openshift-eng/rebasebot/pull/43/commits/0bad75f7da1f9e03f9d0d2d3591d4cc085ff8992) 
the go build step at container image build time expects the vendor dir

- [consider repo to be dirty if it has untracked files](https://github.com/openshift-eng/rebasebot/pull/43/commits/5ce895eb2f68f7e172d9876b6067bbe59164903c) 
since we are checking in the vendor directory, new dependencies
might pop up as untracked files under vendor.
As such we want to detect the repo is dirty when this scenario happens,
so then we can checkin changes to the vendor directory correctly.