### PR TITLE
Batch of updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/python-39
 
 USER root
 
-ENV GO_VERSION=1.20.3
+ENV GO_VERSION=1.21.1
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
     tar -C /usr/local -zxvf - go/bin go/pkg/tool
 ENV PATH="/usr/local/go/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ lint:
 .PHONY: venv
 venv:
 	$(PYTHON) -m venv env
+
+install:
+	$(PYTHON) -m pip install --user .

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -372,7 +372,11 @@ def _cherrypick_art_pull_request(gitwd: git.Repo, dest_repo: Repository, dest: G
 
             for commit in pull_request.commits():
                 assert isinstance(commit, ShortCommit)
-                gitwd.git.cherry_pick(commit.sha, "-Xtheirs")
+                try:
+                    gitwd.git.cherry_pick(commit.sha, "-Xtheirs")
+                except git.GitCommandError as ex:
+                    if not _resolve_rebase_conflicts(gitwd):
+                        raise RepoException(f"Git rebase failed: {ex}") from ex
 
 
 def _is_push_required(gitwd: git.Repo, dest: GitHubBranch, source: GitHubBranch, rebase: GitHubBranch) -> bool:


### PR DESCRIPTION
Updates version of go to 1.21.1.
Adds make target for local installation.
Fixes conflicts not being resolved when cherry-picking ART PR.