### PR TITLE
Do not reset downstream-only go modules 

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -76,7 +76,11 @@ def _commit_go_mod_updates(gitwd: git.Repo, source: GitHubBranch) -> None:
                 full_path = os.path.join(module_base_path, filename)
                 if not os.path.exists(full_path):
                     continue
-                gitwd.remotes.source.repo.git.checkout(f"source/{source.branch}", full_path)
+                try:
+                    gitwd.remotes.source.repo.git.checkout(f"source/{source.branch}", full_path)
+                except git.GitCommandError:
+                    logging.debug("go module at %s is downstream only, skip its resetting", module_base_path)
+                    break
 
             proc = subprocess.run(
                 "go mod tidy", cwd=module_base_path, shell=True, check=True, capture_output=True


### PR DESCRIPTION
If the fork has downstream only go modules (e.g. Openshift specific tools) that cannot be found upstream, ignore the checkout error when trying to reset them with their (inexistent) upstream counterpart and continue.


#### Details of the fix:

Previous to this change, one would get:
```
error: pathspec './openshift/tools/go.mod' did not match any file(s) known to git
```
During the automated go mod update step of the RebaseBot, as the tool would attempt to perform a
```
git checkout rebase/v2.3.0 ./openshift/tools/go.mod
```

To reset the go.mod/go.sum file change to the upstream state before running `go mod tidy && go mod vendor` to sync the module up with upstream.

For go modules only existing downstream this checkout would fail as there would be no go.mod in the upstream rebase/v2.3.0 branch.

An example of this was happening during a manual rebase of CAPA, but will start happening with all the CAPI forks now that we added the `./openshift/tools` go module in each of them.