### PR TITLE
OCPCLOUD-2572: Implement lifecycle hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ tags
 
 # Editors
 .idea
+.vscode

--- a/rebasebot/builtin-hooks/example.sh
+++ b/rebasebot/builtin-hooks/example.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+set -o pipefail  # Return the exit status of the last command in the pipe that failed
+
+# This is a example script that can be set up as a hook to inject custom logic into the rebasebot process.
+# To run this script add `--post-init-hook _BUILTIN_/example.sh` to the rebasebot command.
+echo "Hello, from a lifecyclehook!"
+
+echo "Available rebasebot environment variables"
+echo "REBASEBOT_SOURCE: ${REBASEBOT_SOURCE}"
+echo "REBASEBOT_DEST: ${REBASEBOT_DEST}"
+echo "REBASEBOT_REBASE: ${REBASEBOT_REBASE}"
+echo "REBASEBOT_WORKING_DIR: ${REBASEBOT_WORKING_DIR}"
+echo "REBASEBOT_GIT_USERNAME: ${REBASEBOT_GIT_USERNAME}"
+echo "REBASEBOT_GIT_EMAIL: ${REBASEBOT_GIT_EMAIL}"

--- a/rebasebot/builtin-hooks/update_go_modules.sh
+++ b/rebasebot/builtin-hooks/update_go_modules.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+set -o pipefail  # Return the exit status of the last command in the pipe that failed
+
+stage_and_commit(){
+    # If commiter email and name is passed as environment variable then use it.
+    if [[ -z "$REBASEBOT_GIT_USERNAME" || -z "$REBASEBOT_GIT_EMAIL" ]]; then
+        author_flag=()
+    else
+        author_flag=(--author="$REBASEBOT_GIT_USERNAME <$REBASEBOT_GIT_EMAIL>")
+    fi
+
+    if [[ -n $(git status --porcelain) ]]; then
+        git add -A
+        git commit "${author_flag[@]}" -q -m "UPSTREAM: <carry>: Updating and vendoring go modules after an upstream rebase"
+    fi
+}
+
+process_go_mod_updates() {
+    echo "Performing go modules update"
+
+    find . -name 'go.mod' -print0 | while IFS= read -r -d '' go_mod_file; do
+        local module_base_path
+        module_base_path=$(dirname "$go_mod_file")
+
+        # Reset go.mod and go.sum to make sure they are the same as in the source
+        for filename in "go.mod" "go.sum"; do
+            local full_path="$module_base_path/$filename"
+            if [[ ! -f "$full_path" ]]; then
+                continue
+            fi
+            if ! git checkout "source/$REBASEBOT_SOURCE" -- "$full_path"; then
+                echo "go module at $module_base_path is downstream only, skip its resetting"
+                break
+            fi
+        done
+
+        echo "go mod tidy output for $full_path"
+        if ! go mod tidy; then
+            echo "Unable to run 'go mod tidy' in $module_base_path" >&2
+            exit 1
+        fi
+
+        echo "go mod vendor output for $full_path"
+        if ! go mod vendor; then
+            echo "Unable to run 'go mod vendor' in $module_base_path" >&2
+            exit 1
+        fi
+    done
+
+    stage_and_commit
+}
+
+# Check if the source branch environment variable is set
+if [[ -z "$REBASEBOT_SOURCE" ]]; then
+    echo "The environment variable REBASEBOT_SOURCE is not set." >&2
+    exit 1
+fi
+
+process_go_mod_updates

--- a/rebasebot/github.py
+++ b/rebasebot/github.py
@@ -76,6 +76,7 @@ class GithubAppProvider:
 
     def __init__(
             self,
+            *,
             app_id: Optional[int] = None,
             app_key: Optional[bytes] = None,
             dest_branch: Optional[GitHubBranch] = None,

--- a/rebasebot/lifecycle_hooks.py
+++ b/rebasebot/lifecycle_hooks.py
@@ -1,0 +1,174 @@
+#    Copyright 2024 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""This module manages user provided scripts that are executed during the rebase process."""
+
+import logging
+import os
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+from enum import Enum
+
+import git
+
+
+class LifecycleHook(Enum):
+    """LifecycleHook is an enum of points of the rebase process where scripts can be attached."""
+    PRE_REBASE = "preRebaseHook"
+    PRE_CARRY_COMMIT = "preCarryCommitHook"
+    POST_REBASE = "postRebaseHook"
+    PRE_PUSH_REBASE_BRANCH = "prePushRebaseBranchHook"
+    PRE_CREATE_PR = "preCreatePRHook"
+
+
+class LifecycleHookScript:
+    """LifecycleHookScript represents a script file that can be executed."""
+    script_location: str  # The user-defined location of the script
+    script_file_path: str  # The resolved absolute path to the script
+
+    def __init__(self, script_location: str):
+        self.script_location = script_location
+        if script_location.startswith("git:"):
+            return
+
+        # Replace _BUILTIN_ with the absolute path to the builtin scripts directory
+        builtin_hooks_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "builtin-hooks")
+        script_file_path = script_location.replace("_BUILTIN_", builtin_hooks_path)
+        # Save absolute path as the working directory changes during execution
+        script_file_path = os.path.abspath(script_file_path)
+        if not os.path.exists(script_file_path):
+            raise ValueError(f"Script file {script_file_path} does not exist")
+        self.script_file_path = script_file_path
+
+    def fetch_from_git(self, gitwd: git.Repo, temp_hook_dir: str):
+        """Fetches the script from a git repository and stores it in a temporary directory."""
+        # Checks if the script path references a git branch
+        # The format is git:<git_reference>:<file_path>
+        if self.script_location.startswith("git:"):
+            git_location = self.script_location[4:]
+            git_ref, file_path = git_location.split(":", 1)
+
+            # 5-digit hash to avoid name conflicts with other scripts that have the same name
+            hash_suffix = str(abs(hash(git_location)))[:5]
+            basename, ext = os.path.splitext(os.path.basename(file_path))
+            self.script_file_path = f"{temp_hook_dir}{basename}-{hash_suffix}{ext}"
+            try:
+                with open(f"{self.script_file_path}", "w", encoding='latin1') as f:
+                    f.write(gitwd.git.show(f"{git_ref}:{file_path}"))
+            except git.GitCommandError as e:
+                raise ValueError(f"Failed to retrieve script from git reference {git_ref}") from e
+            os.chmod(f"{self.script_file_path}", 0o755)  # Make it executable
+
+    def __str__(self):
+        return self.script_location
+
+    def __call__(self):
+        try:
+            with subprocess.Popen(
+                [self.script_file_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            ) as process:
+
+                streams = [process.stdout, process.stderr]
+
+                while streams:
+                    # Wait for output from both stdout and stderr
+                    readable, _, _ = select.select(streams, [], [])
+                    for stream in readable:
+                        line = stream.readline()
+                        if line:
+                            if stream == process.stderr:
+                                print(line, file=sys.stderr, end='')
+                            else:
+                                print(line, end='')
+                        else:
+                            # Remove closed stream from the list
+                            streams.remove(stream)
+
+                # Wait for the process to finish
+                return_code = process.poll()
+                if return_code != 0:
+                    raise subprocess.CalledProcessError(return_code, self.script_file_path)
+
+        except subprocess.CalledProcessError as e:
+            print(f"Script failed with error:\n{e}")
+
+
+def _setup_environment_variables(args):
+    """Sets up environment variables with rebasebot parameters for lifecycle hook scripts."""
+    os.environ["REBASEBOT_SOURCE"] = args.source.branch
+    os.environ["REBASEBOT_DEST"] = args.dest.branch
+    os.environ["REBASEBOT_REBASE"] = args.rebase.branch
+    os.environ["REBASEBOT_WORKING_DIR"] = args.working_dir
+    os.environ["REBASEBOT_GIT_USERNAME"] = args.git_username
+    os.environ["REBASEBOT_GIT_EMAIL"] = args.git_email
+
+
+class LifecycleHooks:
+    """LifecycleHooks stores lifecycle hook scripts and handles setup and teardown of temporary script files."""
+    hooks: dict[LifecycleHook, list[LifecycleHookScript]] = {}
+    tmp_hook_scripts_dir: str = None
+
+    def attach_script_to_hook(self, hook: LifecycleHook, script: LifecycleHookScript):
+        """Adds a script to the specified hook."""
+        if hook not in self.hooks:
+            self.hooks[hook] = []
+        self.hooks[hook].append(script)
+
+    def __init__(self, args=None):
+        if args is None:
+            return
+
+        _setup_environment_variables(args)
+
+        if args.pre_rebase_hook is not None:
+            for script_file_path in args.pre_rebase_hook:
+                self.attach_script_to_hook(LifecycleHook.PRE_REBASE, LifecycleHookScript(script_file_path))
+        if args.pre_carry_commit_hook is not None:
+            for script_file_path in args.pre_carry_commit_hook:
+                self.attach_script_to_hook(LifecycleHook.PRE_CARRY_COMMIT, LifecycleHookScript(script_file_path))
+        if args.post_rebase_hook is not None:
+            for script_file_path in args.post_rebase_hook:
+                self.attach_script_to_hook(LifecycleHook.POST_REBASE, LifecycleHookScript(script_file_path))
+        if args.update_go_modules is True:
+            self.attach_script_to_hook(LifecycleHook.POST_REBASE, LifecycleHookScript("_BUILTIN_/update_go_modules.sh"))
+        if args.pre_push_rebase_branch_hook is not None:
+            for script_file_path in args.pre_push_rebase_branch_hook:
+                self.attach_script_to_hook(LifecycleHook.PRE_PUSH_REBASE_BRANCH, LifecycleHookScript(script_file_path))
+        if args.pre_create_pr_hook is not None:
+            for script_file_path in args.pre_create_pr_hook:
+                self.attach_script_to_hook(LifecycleHook.PRE_CREATE_PR, LifecycleHookScript(script_file_path))
+
+    def __del__(self):
+        """Cleans up temporary script directory"""
+        if self.tmp_hook_scripts_dir is not None:
+            shutil.rmtree(self.tmp_hook_scripts_dir)
+
+    def fetch_hook_scripts(self, gitwd: git.Repo):
+        """Fetches the hooks scripts stored in git repository"""
+        self.tmp_hook_scripts_dir = tempfile.mkdtemp()
+        for hooks in self.hooks.values():
+            for script in hooks:
+                script.fetch_from_git(gitwd, self.tmp_hook_scripts_dir)
+
+    def execute_scripts_for_hook(self, hook: LifecycleHook):
+        """Executes all scripts in the given lifecycle hook."""
+        for script in self.hooks.get(hook, []):
+            logging.info(f"Running {hook} lifecycle hook {script}")
+            script()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import setuptools
 
 setuptools.setup(
@@ -8,5 +9,7 @@ setuptools.setup(
    author_email='mfedosin@redhat.com',
    packages=['rebasebot'],
    install_requires=['cryptography', 'gitpython', 'github3.py', 'requests', 'validators'], #external packages as dependencies
-   scripts=['rebasebot/cli.py']
+   scripts=['rebasebot/cli.py'],
+   include_package_data=True,
+   package_data={'rebasebot': ['builtin-hooks/*']}
 )


### PR DESCRIPTION
This PR implements the ability for user specified scripts to be executed during the rebase process. This enables automation of tasks that are required on some repositories. Like code generation.

The original design had more hooks planed. Especially in earlier stages. But I decided to not implement them. As it is difficult to implement them and I could not think of a compelling case that would require them. I suspect the most common use case will be to run a post rebase hook to automate some generation step. If the need for more hook arises, we can extend the feature.

I have reimplemented the rebasebot go vendor updating feature as a lifecycle hook script as a first use of the feature. It is still available through the original parameter to not break users. It should be 1:1 reimplementation in bash.