### PR TITLE
Update dependencies in image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi9/python-39
+FROM registry.access.redhat.com/ubi9/python-311
 
 USER root
 
-ENV GO_VERSION=1.21.1
+ENV GO_VERSION=1.22.8
 RUN curl -Ls https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | \
-    tar -C /usr/local -zxvf - go/bin go/pkg/tool go/go.env
+    tar -C /usr/local -zxvf - go/
 ENV PATH="/usr/local/go/bin:$PATH"
 
 WORKDIR /src


### PR DESCRIPTION
Updates the image to python-3.11 and go 1.22.

We now require go/src for the manifest generation lifecyclehook script.
I decided to extract the entire go/ as picking out only parts is a common source of bugs and the space savings are no longer worth it, (202/223) MB.