### PR TITLE
OCPCLOUD-2757: Implement dynamic source ref hook scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON=python3
 .PHONY: deps
 deps:
 	$(PYTHON) -m pip install --upgrade pip
-	$(PYTHON) -m pip install -r requirements-hacking.txt
+	$(PYTHON) -m pip install --upgrade -r requirements-hacking.txt
 
 .PHONY: unittests
 unittests:

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -645,7 +645,7 @@ def run(
     gh_cloner_app = github_app_provider.github_cloner_app
 
     if hooks is None:
-        hooks = lifecycle_hooks.LifecycleHooks()
+        hooks = lifecycle_hooks.LifecycleHooks(tmp_script_dir=None, args=None)
 
     try:
         dest_repo = gh_app.repository(dest.ns, dest.name)
@@ -691,15 +691,22 @@ def run(
             git_email=git_email
         )
     except Exception as ex:
-        logging.exception("error initializing the git directory", extra={"working_dir": working_dir})
+        logging.exception(
+            "error initializing the git directory with remotes: ",
+            extra={"working_dir": working_dir,
+                   "source_repo": source.url,
+                   "dest_repo": dest.url,
+                   "rebase_repo": rebase.url}
+        )
         _message_slack(
             slack_webhook,
-            f"I got an error initializing the git directory: {ex}"
+            f"I got an error initializing the git directory with remotes: source repo {source.url}, "
+            f"destination repo {dest.url}, rebase repo {rebase.url}: {ex}"
         )
         return False
 
     try:
-        hooks.fetch_hook_scripts(gitwd)
+        hooks.fetch_hook_scripts(gitwd=gitwd, github_app_provider=github_app_provider)
     except Exception as ex:
         logging.exception("error fetching lifecycle hook scripts")
         _message_slack(

--- a/rebasebot/builtin-hooks/source-ref-hooks/latest-stable-release.sh
+++ b/rebasebot/builtin-hooks/source-ref-hooks/latest-stable-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+# Validate REBASEBOT_SOURCE_REPO format
+if [ -z "$REBASEBOT_SOURCE_REPO" ]; then
+    echo "Error: REBASEBOT_SOURCE_REPO environment variable not set" >&2
+    exit 1
+fi
+
+if ! [[ "$REBASEBOT_SOURCE_REPO" =~ ^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$ ]]; then
+    echo "Error: REBASEBOT_SOURCE_REPO must be in 'organization/repository' format" >&2
+    exit 1
+fi
+
+
+# Fetch latest stable release tag
+UPSTREAM_VERSION=$(curl -s \
+    --header "X-GitHub-Api-Version:2022-11-28" \
+    "https://api.github.com/repos/$REBASEBOT_SOURCE_REPO/releases" | \
+    grep '"tag_name":' | \
+    grep -vE '(alpha|beta|rc)' | \
+    sed -E 's/.*"([^"]+)".*/\1/' | \
+    sed '/-/!{s/$/_/}' | \
+    sort -V | \
+    sed 's/_$//' | \
+    tail -n1)
+
+# Print only the tag name
+echo "$UPSTREAM_VERSION"

--- a/rebasebot/lifecycle_hooks.py
+++ b/rebasebot/lifecycle_hooks.py
@@ -18,14 +18,17 @@ import logging
 import os
 import re
 import select
-import shutil
 import subprocess
 import sys
-import tempfile
 from enum import Enum
 
+from dataclasses import dataclass
+from typing import List
+from github3.repos.contents import Contents
 import git
 import git.repo
+
+from rebasebot.github import GithubAppProvider, parse_github_branch
 
 
 class LifecycleHookScriptException(Exception):
@@ -41,6 +44,18 @@ class LifecycleHook(Enum):
     PRE_CREATE_PR = "preCreatePRHook"
 
 
+@dataclass
+class LifecycleHookScriptResult:
+    """LifecycleHookScriptResult stores output from LifecycleHookScript"""
+    return_code: int
+    stdout: list[str]
+    stderr: list[str]
+
+    def __repr__(self):
+        return (f"LifecycleHookScriptResult(return_code={self.return_code}, "
+                f"stdout={repr(self.stdout)}, stderr={repr(self.stderr)})")
+
+
 class LifecycleHookScript:
     """LifecycleHookScript represents a script file that can be executed."""
 
@@ -50,66 +65,132 @@ class LifecycleHookScript:
         if script_location.startswith("git:"):
             return
 
-        # Replace _BUILTIN_ with the absolute path to the builtin scripts directory
-        builtin_hooks_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "builtin-hooks")
-        script_file_path = script_location.replace("_BUILTIN_", builtin_hooks_path)
+        # Replace _BUILTIN_ with the absolute path to the builtin scripts
+        # directory
+        builtin_hooks_path = os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "builtin-hooks")
+        script_file_path = script_location.replace(
+            "_BUILTIN_", builtin_hooks_path)
         # Save absolute path as the working directory changes during execution
         script_file_path = os.path.abspath(script_file_path)
         if not os.path.exists(script_file_path):
             raise ValueError(f"Script file {script_file_path} does not exist")
         self.script_file_path = script_file_path
 
-    def fetch_from_git(self, gitwd: git.Repo, temp_hook_dir: str):
-        """Fetches the script from a git repository and stores it in a temporary directory."""
+    def _fetch_from_local_git(
+            self, gitwd: git.Repo, git_ref: str, file_path: str, script_file_path: str):
+        """Fetches script from local git repository."""
+        git_path = f"{git_ref}:{file_path}"
+        try:
+            script_content = _retrieve_file_from_git(gitwd, git_path)
+            with open(script_file_path, "w", encoding='latin1') as f:
+                f.write(script_content)
+                os.chmod(script_file_path, 0o755)  # Make it executable
+        except git.GitCommandError as e:
+            raise ValueError(
+                f"Failed to retrieve script from git reference {git_path}") from e
+        except Exception as e:
+            raise ValueError(
+                f"Failed to write script to file {script_file_path}") from e
+
+    def _fetch_from_remote_git(self, *, gitwd: git.Repo, repo_url: str, domain: str, organization: str,
+                               name: str, branch: str, git_repo_path_to_script: str, script_file_path: str):
+        """Fetches script from remote git repository."""
+        # Add the remote if it doesn't already exist
+        if not any(
+                remote.name == f"{domain}/{organization}/{name}" for remote in gitwd.remotes):
+            try:
+                gitwd.create_remote(
+                    f"{domain}/{organization}/{name}", repo_url)
+            except git.GitCommandError as e:
+                raise ValueError(
+                    f"Failed to add remote domain/{organization}/{name}") from e
+
+        # Blobless fetch of the branch
+        try:
+            _fetch_branch(
+                gitwd, f"{domain}/{organization}/{name}", branch, ref_filter="blob:none")
+        except git.GitCommandError as e:
+            raise ValueError(f"Failed to fetch branch {branch}") from e
+
+        git_path = f"{domain}/{organization}/{name}/{branch}:{git_repo_path_to_script}"
+        try:
+            script_content = _retrieve_file_from_git(gitwd, git_path)
+            with open(f"{script_file_path}", "w", encoding="utf-8") as f:
+                f.write(script_content)
+            os.chmod(f"{script_file_path}", 0o755)  # Make it executable
+        except git.GitCommandError as e:
+            raise ValueError(
+                f"Failed to retrieve script from git reference {git_path}") from e
+
+    def _fetch_from_github_api(self, *, github, organization: str, name: str,
+                               git_repo_path_to_script: str, branch: str, script_file_path: str):
+        """Fetches script from GitHub API."""
+        try:
+            script: Contents = _fetch_file_from_github(
+                github, organization, name, branch, git_repo_path_to_script)
+            with open(script_file_path, "wb",) as f:
+                f.write(script.decoded)
+            os.chmod(script_file_path, 0o755)  # Make it executable
+        except Exception as e:
+            raise ValueError(
+                f"Failed to retrieve script from github organization={organization}, "
+                "name={name}, branch={branch}, path={git_repo_path_to_script},") from e
+
+    def _extract_script_details(
+            self, script_location: str, temp_hook_dir: str) -> tuple[str, str, str]:
+        """Extracts script details and generates the script file path."""
+        git_location = script_location[4:]
+        git_ref, file_path = git_location.split(":", 1)
+
+        # 5-digit hash to avoid name conflicts with other scripts that have the
+        # same name
+        hash_suffix = str(abs(hash(git_location)))[:5]
+        basename, ext = os.path.splitext(os.path.basename(file_path))
+        script_file_path = f"{temp_hook_dir}/{basename}-{hash_suffix}{ext}"
+        return git_ref, file_path, script_file_path
+
+    def fetch_script(self, temp_hook_dir: str,
+                     gitwd: git.Repo = None, github: GithubAppProvider = None):
+        """Fetches the script from a git repository and stores it in a temporary directory.
+        Prefers github API when source is GitHub, otherwise uses generic git library when available.
+        """
         if not self.script_location.startswith("git:"):
             return
 
-        git_location = self.script_location[4:]
-        git_ref, file_path = git_location.split(":", 1)
+        git_ref, file_path, self.script_file_path = self._extract_script_details(
+            self.script_location, temp_hook_dir)
 
-        # 5-digit hash to avoid name conflicts with other scripts that have the same name
-        hash_suffix = str(abs(hash(git_location)))[:5]
-        basename, ext = os.path.splitext(os.path.basename(file_path))
-        self.script_file_path = f"{temp_hook_dir}/{basename}-{hash_suffix}{ext}"
+        remote_git_pattern_match = re.match(
+            "^git:(https://([^/]+)/([^/]+)/([^/]+))/([^/]*?):(.*)$", self.script_location)
+        local_git_pattern_match = re.match(
+            "^git:([^:]+):([^:]+)$", self.script_location)
 
-        remote_git_pattern_match = re.match("^git:(https://([^/]+)/([^/]+)/([^/]+))/([^/]*?):(.*)$",
-                                            self.script_location)
-        local_git_pattern_match = re.match("^git:([^:]+):([^:]+)$", self.script_location)
         if remote_git_pattern_match:
             repo_url, domain, organization, name, branch, path_to_script = remote_git_pattern_match.groups()
 
-            # Add the remote if it doesn't already exist
-            if not any(remote.name == f"{domain}/{organization}/{name}" for remote in gitwd.remotes):
-                try:
-                    gitwd.create_remote(f"{domain}/{organization}/{name}", repo_url)
-                except git.GitCommandError as e:
-                    raise ValueError(f"Failed to add remote domain/{organization}/{name}") from e
-
-            # Blobless fetch of the branch
-            try:
-                _fetch_branch(gitwd, f"{domain}/{organization}/{name}", branch, ref_filter="blob:none")
-            except git.GitCommandError as e:
-                raise ValueError(f"Failed to fetch branch {branch}") from e
-
-            git_path = f"{domain}/{organization}/{name}/{branch}:{path_to_script}"
-        elif local_git_pattern_match:
-            git_path = f"{git_ref}:{file_path}"
+            if domain == "github.com" and github:
+                self._fetch_from_github_api(
+                    github=github, organization=organization, name=name, git_repo_path_to_script=path_to_script,
+                    branch=branch, script_file_path=self.script_file_path)
+            elif gitwd:
+                self._fetch_from_remote_git(
+                    gitwd=gitwd, repo_url=repo_url, domain=domain, organization=organization, name=name,
+                    branch=branch, git_repo_path_to_script=path_to_script, script_file_path=self.script_file_path)
+            else:
+                raise ValueError(
+                    "gitwd or GithubAppProvider instance required to fetch from remote git repository")
+        elif local_git_pattern_match and gitwd:
+            self._fetch_from_local_git(
+                gitwd, git_ref, file_path, self.script_file_path)
         else:
-            raise ValueError(f"LifecycleHook script is not in valid format: {self.script_location}")
-
-        # Create the script file
-        try:
-            with open(f"{self.script_file_path}", "w", encoding='latin1') as f:
-                file = _retrieve_file_from_git(gitwd, git_path)
-                f.write(file)
-        except git.GitCommandError as e:
-            raise ValueError(f"Failed to retrieve script from git reference {git_ref}") from e
-        os.chmod(f"{self.script_file_path}", 0o755)  # Make it executable
+            raise ValueError(
+                f"LifecycleHook script is not in valid format: {self.script_location}")
 
     def __str__(self):
         return self.script_location
 
-    def __call__(self):
+    def __call__(self) -> LifecycleHookScriptResult:
         with subprocess.Popen(
             [self.script_file_path],
             stdout=subprocess.PIPE,
@@ -117,29 +198,42 @@ class LifecycleHookScript:
             text=True
         ) as process:
 
-            streams = [process.stdout, process.stderr]
+            stdout_lines: List[str] = []
+            stderr_lines: List[str] = []
+            streams = {process.stdout: stdout_lines,
+                       process.stderr: stderr_lines}
 
             while streams:
-                # Wait for output from both stdout and stderr
-                readable, _, _ = select.select(streams, [], [])
+                readable, _, _ = select.select(streams.keys(), [], [])
                 for stream in readable:
                     line = stream.readline()
                     if line:
+                        streams[stream].append(line)
                         if stream == process.stderr:
                             print(line, file=sys.stderr, end='')
                         else:
                             print(line, end='')
                     else:
                         # Remove closed stream from the list
-                        streams.remove(stream)
+                        del streams[stream]
 
             # Wait for the process to finish
-            return_code = process.poll()
-            if return_code != 0:
-                raise subprocess.CalledProcessError(return_code, self.script_file_path)
+            return_code = process.wait()
+            return LifecycleHookScriptResult(
+                return_code=return_code,
+                stdout=stdout_lines,
+                stderr=stderr_lines
+            )
 
 
-def _fetch_branch(gitwd: git.Repo, remote: str, branch: str, ref_filter: str = None):
+def _fetch_file_from_github(
+        github, organization, name, branch, git_repo_path_to_script) -> Contents:
+    return github.github_cloner_app.repository(
+        owner=organization, repository=name).file_contents(git_repo_path_to_script, ref=branch)
+
+
+def _fetch_branch(gitwd: git.Repo, remote: str,
+                  branch: str, ref_filter: str = None):
     return gitwd.git.fetch(remote, branch, filter=ref_filter)
 
 
@@ -157,61 +251,100 @@ def _setup_environment_variables(args):
     os.environ["REBASEBOT_GIT_EMAIL"] = args.git_email
 
 
+def run_source_repo_hook(args, github_app_wrapper, temp_script_dir):
+    """
+    run_source_repo_hook fetches the specified repository hook script and runs it.
+
+    Source repository script contract:
+        Input environment variables:
+            REBASEBOT_SOURCE_REPO: organization/repository_name
+
+        Output:
+            Source branch name as the only printed out line
+    """
+    os.environ["REBASEBOT_SOURCE_REPO"] = args.source_repo
+    source_hook = LifecycleHookScript(args.source_branch_hook)
+    source_hook.fetch_script(
+        temp_hook_dir=temp_script_dir, github=github_app_wrapper)
+    result = source_hook()
+
+    if result.return_code != 0:
+        error_message = '\n'.join(
+            result.stderr) if result.stderr else "Unknown error occurred"
+        raise RuntimeError(
+            f"Hook script failed with return code {result.return_code}. Error: {error_message}")
+
+    if result.stdout:
+        # Expecting the first line of stdout to be the branch name
+        branch_name = result.stdout[0].strip()
+        if not re.match("^[a-zA-Z0-9/._-]{1,100}$", branch_name):
+            raise ValueError(f"\"{branch_name}\" is not valid branch name")
+    else:
+        raise ValueError("No branch name returned in stdout")
+
+    args.source = parse_github_branch(f"{args.source_repo}:{branch_name}")
+
+
 class LifecycleHooks:
     """LifecycleHooks stores lifecycle hook scripts and handles setup and teardown of temporary script files."""
 
-    def __init__(self, args=None):
+    def __init__(self, tmp_script_dir: str, args):
         self.hooks: dict[LifecycleHook, list[LifecycleHookScript]] = {}
-        self.tmp_hook_scripts_dir: str = None
-
-        if args is None:
-            return
+        self.tmp_hook_scripts_dir = tmp_script_dir
 
         _setup_environment_variables(args)
 
         if args.pre_rebase_hook is not None:
             for script_file_path in args.pre_rebase_hook:
-                self.attach_script_to_hook(LifecycleHook.PRE_REBASE, LifecycleHookScript(script_file_path))
+                self.attach_script_to_hook(
+                    LifecycleHook.PRE_REBASE, LifecycleHookScript(script_file_path))
         if args.pre_carry_commit_hook is not None:
             for script_file_path in args.pre_carry_commit_hook:
-                self.attach_script_to_hook(LifecycleHook.PRE_CARRY_COMMIT, LifecycleHookScript(script_file_path))
+                self.attach_script_to_hook(
+                    LifecycleHook.PRE_CARRY_COMMIT, LifecycleHookScript(script_file_path))
         if args.post_rebase_hook is not None:
             for script_file_path in args.post_rebase_hook:
-                self.attach_script_to_hook(LifecycleHook.POST_REBASE, LifecycleHookScript(script_file_path))
+                self.attach_script_to_hook(
+                    LifecycleHook.POST_REBASE, LifecycleHookScript(script_file_path))
         if args.update_go_modules is True:
-            self.attach_script_to_hook(LifecycleHook.POST_REBASE, LifecycleHookScript("_BUILTIN_/update_go_modules.sh"))
+            self.attach_script_to_hook(LifecycleHook.POST_REBASE, LifecycleHookScript(
+                "_BUILTIN_/update_go_modules.sh"))
         if args.pre_push_rebase_branch_hook is not None:
             for script_file_path in args.pre_push_rebase_branch_hook:
-                self.attach_script_to_hook(LifecycleHook.PRE_PUSH_REBASE_BRANCH, LifecycleHookScript(script_file_path))
+                self.attach_script_to_hook(
+                    LifecycleHook.PRE_PUSH_REBASE_BRANCH, LifecycleHookScript(script_file_path))
         if args.pre_create_pr_hook is not None:
             for script_file_path in args.pre_create_pr_hook:
-                self.attach_script_to_hook(LifecycleHook.PRE_CREATE_PR, LifecycleHookScript(script_file_path))
+                self.attach_script_to_hook(
+                    LifecycleHook.PRE_CREATE_PR, LifecycleHookScript(script_file_path))
 
-    def attach_script_to_hook(self, hook: LifecycleHook, script: LifecycleHookScript):
+    def attach_script_to_hook(self, hook: LifecycleHook,
+                              script: LifecycleHookScript):
         """Adds a script to the specified hook."""
         if hook not in self.hooks:
             self.hooks[hook] = []
         self.hooks[hook].append(script)
 
-    def __del__(self):
-        """Cleans up temporary script directory"""
-        if self.tmp_hook_scripts_dir is not None:
-            shutil.rmtree(self.tmp_hook_scripts_dir)
-
-    def fetch_hook_scripts(self, gitwd: git.Repo):
+    def fetch_hook_scripts(self, gitwd: git.Repo,
+                           github_app_provider: GithubAppProvider):
         """Fetches the hooks scripts stored in git repository"""
-        self.tmp_hook_scripts_dir = tempfile.mkdtemp()
         for hooks in self.hooks.values():
             for script in hooks:
-                script.fetch_from_git(gitwd, self.tmp_hook_scripts_dir)
+                script.fetch_script(
+                    temp_hook_dir=self.tmp_hook_scripts_dir, gitwd=gitwd, github=github_app_provider)
 
     def execute_scripts_for_hook(self, hook: LifecycleHook):
         """Executes all scripts in the given lifecycle hook."""
         for script in self.hooks.get(hook, []):
             logging.info(f"Running {hook} lifecycle hook {script}")
             try:
-                script()
+                result = script()
+                if result.return_code != 0:
+                    raise subprocess.CalledProcessError(
+                        result.return_code, cmd=script.script_file_path, output="\n".join(result.stdout),
+                        stderr="\n".join(result.stderr))
             except subprocess.CalledProcessError as err:
-                logging.error(f"Script {script} failed with exit code {err.returncode}")
+                logging.error(
+                    f"Script {script} failed with exit code {err.returncode}")
                 message = f"{hook} script {script} failed with exit-code {err.returncode}"
                 raise LifecycleHookScriptException(message) from err

--- a/tests/data/test-source-branch-hook-script.sh
+++ b/tests/data/test-source-branch-hook-script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo release-0.1

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -51,8 +51,10 @@ class TestGoMod:
         repo.create_remote("source", source.url)
         repo.remotes.source.fetch(source.branch)
 
-        lifecycle_hooks._setup_environment_variables(self._args_stub(repo_dir, source))
-        update_go_modules_script = lifecycle_hooks.LifecycleHookScript("_BUILTIN_/update_go_modules.sh")
+        lifecycle_hooks._setup_environment_variables(
+            self._args_stub(repo_dir, source))
+        update_go_modules_script = lifecycle_hooks.LifecycleHookScript(
+            "_BUILTIN_/update_go_modules.sh")
         update_go_modules_script()
 
         commits = list(repo.iter_commits())
@@ -77,8 +79,10 @@ class TestGoMod:
         repo.create_remote("source", source.url)
         repo.remotes.source.fetch(source.branch)
 
-        lifecycle_hooks._setup_environment_variables(self._args_stub(repo_dir, source))
-        update_go_modules_script = lifecycle_hooks.LifecycleHookScript("_BUILTIN_/update_go_modules.sh")
+        lifecycle_hooks._setup_environment_variables(
+            self._args_stub(repo_dir, source))
+        update_go_modules_script = lifecycle_hooks.LifecycleHookScript(
+            "_BUILTIN_/update_go_modules.sh")
         update_go_modules_script()
 
         commits = list(repo.iter_commits())
@@ -127,7 +131,8 @@ class TestCommitMessageTags:
         )
     )
     @patch('rebasebot.bot._is_pr_merged')
-    def test_commit_messages_tags(self, mocked_is_pr_merged, pr_is_merged, commit_message, tag_policy, expected):
+    def test_commit_messages_tags(
+            self, mocked_is_pr_merged, pr_is_merged, commit_message, tag_policy, expected):
         mocked_is_pr_merged.return_value = pr_is_merged
         if isinstance(expected, Exception):
             with pytest.raises(Exception, match=str(expected)):


### PR DESCRIPTION
This PR allows users to specify a script that will be executed before rebasebot starts. This script is used to fetch the desired source branch to be used for the rebase.

This enables integration into CI for rebases that should rebase the latest released version without having to manually update the source tag configuration.