### PR TITLE
Add --conflict-policy flag to detect upstream dropped content

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -312,8 +312,153 @@ def _identify_downstream_commits(gitwd: git.Repo, source: GitHubBranch, dest: Gi
     return downstream_commits
 
 
+def _detect_conflicting_files(gitwd: git.Repo, sha: str) -> set:
+    """
+    Probe a cherry-pick without -Xtheirs to detect which files conflict.
+
+    Attempts the cherry-pick with --no-commit (no merge strategy), records
+    any unmerged files, then resets to the original state.
+
+    Returns a set of filenames that had merge conflicts, or an empty set
+    if the cherry-pick would apply cleanly.
+    """
+    saved_head = gitwd.head.commit.hexsha
+    conflicted = set()
+
+    try:
+        gitwd.git.cherry_pick(sha, "--no-commit")
+    except git.GitCommandError:
+        # Conflicts exist — record which files are unmerged
+        try:
+            unmerged = gitwd.git.diff("--name-only", "--diff-filter=U")
+            if unmerged:
+                conflicted = set(unmerged.splitlines())
+        except git.GitCommandError:
+            pass
+
+    # Reset to original state regardless of success/failure
+    gitwd.git.reset("--hard", saved_head)
+
+    # Clean up any stale cherry-pick state files
+    for name in ("CHERRY_PICK_HEAD", "MERGE_MSG"):
+        state_path = os.path.join(gitwd.git_dir, name)
+        if os.path.exists(state_path):
+            os.remove(state_path)
+
+    return conflicted
+
+
+def _check_upstream_content_loss(
+    gitwd: git.Repo,
+    source_branch: str,
+    only_files: set = None
+) -> list:
+    """
+    After a cherry-pick with -Xtheirs, check whether any upstream content
+    was silently dropped from files modified by the cherry-picked commit.
+
+    Compares each file against the upstream version (source/<branch>).
+    Returns a list of (filename, lost_lines) tuples for files where upstream
+    lines are missing from the result.
+
+    If only_files is provided, only those files are checked (used to
+    restrict verification to files that had actual merge conflicts).
+    """
+    source_ref = f"source/{source_branch}"
+
+    if only_files is not None:
+        files_to_check = only_files
+    else:
+        files_to_check = gitwd.git.diff(
+            "--name-only", "HEAD~1", "HEAD"
+        ).splitlines()
+
+    results = []
+    for f in files_to_check:
+        try:
+            upstream_content = gitwd.git.show(f"{source_ref}:{f}")
+            current_content = gitwd.git.show(f"HEAD:{f}")
+        except git.GitCommandError:
+            # File doesn't exist on one side — not a content loss scenario
+            continue
+
+        upstream_lines = set(
+            line for line in upstream_content.splitlines() if line.strip()
+        )
+        current_lines = set(
+            line for line in current_content.splitlines() if line.strip()
+        )
+        lost_lines = upstream_lines - current_lines
+
+        if lost_lines:
+            results.append((f, sorted(lost_lines)))
+
+    return results
+
+
+def _safe_cherry_pick(
+    gitwd: git.Repo,
+    sha: str,
+    source_branch: str,
+    conflict_policy: str,
+    commit_description: str
+) -> None:
+    """
+    Cherry-pick a commit with conflict detection based on conflict_policy.
+
+    For "auto" policy: behaves exactly as before (-Xtheirs, no checks).
+    For "warn"/"strict" policies: first probes for conflicts without
+    -Xtheirs, then cherry-picks with -Xtheirs, then verifies only the
+    files that actually conflicted for upstream content loss.
+    """
+    # Phase 1: probe for conflicts (only for warn/strict)
+    conflicted_files = set()
+    if conflict_policy != "auto":
+        conflicted_files = _detect_conflicting_files(gitwd, sha)
+
+    # Phase 2: actual cherry-pick with -Xtheirs
+    try:
+        gitwd.git.cherry_pick(f"{sha}", "-Xtheirs")
+    except git.GitCommandError as ex:
+        if not _resolve_rebase_conflicts(gitwd):
+            raise RepoException(f"Git rebase failed: {ex}") from ex
+
+    # If no conflicts were detected, -Xtheirs had no effect — skip check
+    if conflict_policy == "auto" or not conflicted_files:
+        return
+
+    # Only verify files that had actual merge conflicts
+    lost_content = _check_upstream_content_loss(
+        gitwd, source_branch, conflicted_files
+    )
+    if not lost_content:
+        return
+
+    for filename, lost_lines in lost_content:
+        logging.warning(
+            "Upstream content may have been dropped from '%s' "
+            "by cherry-pick of: %s",
+            filename, commit_description
+        )
+        for line in lost_lines[:10]:
+            logging.warning("  lost line: %s", line.strip())
+        if len(lost_lines) > 10:
+            logging.warning(
+                "  ... and %d more lines", len(lost_lines) - 10
+            )
+
+    if conflict_policy == "strict":
+        files = ", ".join(f for f, _ in lost_content)
+        raise RepoException(
+            f"Upstream content was lost in [{files}] after "
+            f"cherry-picking '{commit_description}'. "
+            f"-Xtheirs resolved a content conflict by dropping "
+            f"upstream additions. Manual resolution is required."
+        )
+
+
 def _do_rebase(*, gitwd: git.Repo, source: GitHubBranch, dest: GitHubBranch, source_repo: Repository, tag_policy: str,
-               bot_emails: list, exclude_commits: list, update_go_modules: bool) -> None:
+               conflict_policy: str = "auto", bot_emails: list, exclude_commits: list, update_go_modules: bool) -> None:
     logging.info("Performing rebase")
 
     allow_bot_squash = len(bot_emails) > 0
@@ -356,11 +501,13 @@ def _do_rebase(*, gitwd: git.Repo, source: GitHubBranch, dest: GitHubBranch, sou
 
         logging.info("Picking commit: %s - %s", sha, commit_message)
 
-        try:
-            gitwd.git.cherry_pick(f"{sha}", "-Xtheirs")
-        except git.GitCommandError as ex:
-            if not _resolve_rebase_conflicts(gitwd):
-                raise RepoException(f"Git rebase failed: {ex}") from ex
+        _safe_cherry_pick(
+            gitwd=gitwd,
+            sha=sha,
+            source_branch=source.branch,
+            conflict_policy=conflict_policy,
+            commit_description=f"{sha} - {commit_message}"
+        )
 
     # Here we cherry-pick the bot's commits and then squash them together
     # We also want the newest bot commit message to represent the squashed commits
@@ -368,11 +515,13 @@ def _do_rebase(*, gitwd: git.Repo, source: GitHubBranch, dest: GitHubBranch, sou
         for key, value in commits_to_squash.items():
             logging.info("Squashing commits for bot: %s: %s", key, value)
             for commit in value:
-                try:
-                    gitwd.git.cherry_pick(commit["sha"], "-Xtheirs")
-                except git.GitCommandError as ex:
-                    if not _resolve_rebase_conflicts(gitwd):
-                        raise RepoException(f"Git rebase failed: {ex}") from ex
+                _safe_cherry_pick(
+                    gitwd=gitwd,
+                    sha=commit["sha"],
+                    source_branch=source.branch,
+                    conflict_policy=conflict_policy,
+                    commit_description=f"{commit['sha']} - {commit['commit_message']}"
+                )
             gitwd.git.reset("--soft", f"HEAD~{len(value)}")
 
             newest_bot_commit_message = value[-1]["commit_message"]
@@ -481,7 +630,8 @@ def _resolve_rebase_conflicts(gitwd: git.Repo) -> bool:
         return _resolve_rebase_conflicts(gitwd)
 
 
-def _cherrypick_art_pull_request(gitwd: git.Repo, dest_repo: Repository, dest: GitHubBranch) -> None:
+def _cherrypick_art_pull_request(gitwd: git.Repo, dest_repo: Repository, dest: GitHubBranch,
+                                 conflict_policy: str = "auto") -> None:
     """
     Looks at the destination repository and if there is an open ART pull request
     that updates the build image, it includes it in the rebase.
@@ -502,11 +652,13 @@ def _cherrypick_art_pull_request(gitwd: git.Repo, dest_repo: Repository, dest: G
 
             for commit in pull_request.commits():
                 assert isinstance(commit, ShortCommit)
-                try:
-                    gitwd.git.cherry_pick(commit.sha, "-Xtheirs")
-                except git.GitCommandError as ex:
-                    if not _resolve_rebase_conflicts(gitwd):
-                        raise RepoException(f"Git rebase failed: {ex}") from ex
+                _safe_cherry_pick(
+                    gitwd=gitwd,
+                    sha=commit.sha,
+                    source_branch=dest.branch,
+                    conflict_policy=conflict_policy,
+                    commit_description=f"ART PR commit {commit.sha}"
+                )
 
 
 def _is_push_required(gitwd: git.Repo, rebase: GitHubBranch) -> bool:
@@ -823,6 +975,7 @@ def run(
     github_app_provider: GithubAppProvider,
     slack_webhook: str,
     tag_policy: str,
+    conflict_policy: str = "auto",
     bot_emails: list,
     exclude_commits: list,
     hooks: lifecycle_hooks.LifecycleHooks = None,
@@ -919,12 +1072,13 @@ def run(
                 dest=dest,
                 source_repo=source_repo,
                 tag_policy=tag_policy,
+                conflict_policy=conflict_policy,
                 bot_emails=bot_emails,
                 exclude_commits=exclude_commits,
                 update_go_modules=update_go_modules
             )
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.POST_REBASE)
-            _cherrypick_art_pull_request(gitwd, dest_repo, dest)
+            _cherrypick_art_pull_request(gitwd, dest_repo, dest, conflict_policy)
         elif always_run_hooks:
             # Run hooks without rebase operations when --always-run-hooks is enabled
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.PRE_REBASE)

--- a/rebasebot/cli.py
+++ b/rebasebot/cli.py
@@ -200,6 +200,17 @@ def _parse_cli_arguments():
         help="Option that shows how to handle UPSTREAM tags in "
              "commit messages. (default: %(default)s)")
     parser.add_argument(
+        "--conflict-policy",
+        default="auto",
+        const="auto",
+        nargs="?",
+        choices=["auto", "warn", "strict"],
+        help="Detect upstream content silently dropped by -Xtheirs. "
+             "'auto': no detection. "
+             "'warn': log warnings. "
+             "'strict': fail. "
+             "(default: %(default)s)")
+    parser.add_argument(
         "--bot-emails",
         type=str,
         default=(),
@@ -354,6 +365,7 @@ def rebasebot_run(args, slack_webhook, github_app_wrapper):
                 github_app_provider=github_app_wrapper,
                 slack_webhook=slack_webhook,
                 tag_policy=args.tag_policy,
+                conflict_policy=args.conflict_policy,
                 bot_emails=args.bot_emails,
                 exclude_commits=args.exclude_commits,
                 update_go_modules=args.update_go_modules,

--- a/tests/test_conflict_policy.py
+++ b/tests/test_conflict_policy.py
@@ -1,0 +1,293 @@
+#    Copyright 2026 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Tests for --conflict-policy behavior."""
+
+from __future__ import annotations
+import logging
+from unittest.mock import MagicMock, patch
+
+from rebasebot import cli
+from .conftest import CommitBuilder
+
+# File content simulating upstream with original formatting
+_ORIGINAL_CODE = """\
+package main
+
+const (
+\tregionKey    = "region"
+\tebsCSIDriver = "ebs.csi.aws.com"
+)
+
+type Snapshotter struct {
+\tlog string
+\tec2 string
+}
+"""
+
+# Upstream adds a new field/constant (between existing lines)
+_UPSTREAM_ADDED_CODE = """\
+package main
+
+const (
+\tregionKey      = "region"
+\tebsKmsKeyIDKey = "ebsKmsKeyId"
+\tebsCSIDriver   = "ebs.csi.aws.com"
+)
+
+type Snapshotter struct {
+\tlog         string
+\tec2         string
+\tebsKmsKeyId string
+}
+"""
+
+# Downstream carry patch reformats and adds its own field/constant
+# (conflicts with upstream because it modifies the same lines)
+_DOWNSTREAM_CARRY_CODE = """\
+package main
+
+const (
+\tregionKey                      = "region"
+\tebsCSIDriver                   = "ebs.csi.aws.com"
+\tsnapshotCreationTimeoutKey     = "snapshotCreationTimeout"
+)
+
+type Snapshotter struct {
+\tlog                     string
+\tec2                     string
+\tsnapshotCreationTimeout string
+}
+"""
+
+
+class TestConflictPolicy:
+    """Tests that --conflict-policy correctly detects upstream content loss."""
+
+    @patch("rebasebot.bot._create_pr")
+    @patch("rebasebot.bot._push_rebase_branch")
+    @patch("rebasebot.bot._is_pr_available")
+    @patch("rebasebot.bot._message_slack")
+    def test_auto_policy_silent_on_conflict(
+        self, mocked_message_slack, mocked_is_pr_available,
+        mocked_push_rebase_branch, mocked_create_pr,
+        init_test_repositories, fake_github_provider, tmpdir
+    ):
+        """With auto policy, -Xtheirs conflicts resolve silently."""
+        source, rebase, dest = init_test_repositories
+        mocked_is_pr_available.return_value = None, False
+        mocked_push_rebase_branch.return_value = True
+
+        # Replace test.go with structured code in source (initial state)
+        CommitBuilder(source).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("set up base code")
+
+        # Sync dest to have the same base
+        CommitBuilder(dest).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("UPSTREAM: <carry>: sync base")
+
+        # Upstream adds new fields
+        CommitBuilder(source).update_file(
+            "test.go", _UPSTREAM_ADDED_CODE
+        ).commit("Add KMS key support")
+
+        # Downstream carry patch reformats and adds timeout
+        CommitBuilder(dest).update_file(
+            "test.go", _DOWNSTREAM_CARRY_CODE
+        ).commit("UPSTREAM: <carry>: add snapshot timeout")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.conflict_policy = "auto"
+        args.bot_emails = []
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.ignore_manual_label = False
+        args.dry_run = True
+
+        result = cli.rebasebot_run(
+            args, slack_webhook=None,
+            github_app_wrapper=fake_github_provider)
+        # Should succeed silently
+        assert result is True
+
+    @patch("rebasebot.bot._create_pr")
+    @patch("rebasebot.bot._push_rebase_branch")
+    @patch("rebasebot.bot._is_pr_available")
+    @patch("rebasebot.bot._message_slack")
+    def test_warn_policy_logs_warning_on_content_loss(
+        self, mocked_message_slack, mocked_is_pr_available,
+        mocked_push_rebase_branch, mocked_create_pr,
+        init_test_repositories, fake_github_provider, tmpdir, caplog
+    ):
+        """With warn policy, warnings are logged but rebase succeeds."""
+        source, rebase, dest = init_test_repositories
+        mocked_is_pr_available.return_value = None, False
+        mocked_push_rebase_branch.return_value = True
+
+        CommitBuilder(source).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("set up base code")
+
+        CommitBuilder(dest).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("UPSTREAM: <carry>: sync base")
+
+        CommitBuilder(source).update_file(
+            "test.go", _UPSTREAM_ADDED_CODE
+        ).commit("Add KMS key support")
+
+        CommitBuilder(dest).update_file(
+            "test.go", _DOWNSTREAM_CARRY_CODE
+        ).commit("UPSTREAM: <carry>: add snapshot timeout")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.conflict_policy = "warn"
+        args.bot_emails = []
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.ignore_manual_label = False
+        args.dry_run = True
+
+        with caplog.at_level(logging.WARNING):
+            result = cli.rebasebot_run(
+                args, slack_webhook=None,
+                github_app_wrapper=fake_github_provider)
+
+        assert result is True
+        warning_messages = [
+            r.message.lower() for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ]
+        assert any(
+            "upstream content may have been dropped" in m
+            for m in warning_messages
+        ), f"Expected warning about dropped content, got: {warning_messages}"
+
+    @patch("rebasebot.bot._create_pr")
+    @patch("rebasebot.bot._push_rebase_branch")
+    @patch("rebasebot.bot._is_pr_available")
+    @patch("rebasebot.bot._message_slack")
+    def test_strict_policy_fails_on_content_loss(
+        self, mocked_message_slack, mocked_is_pr_available,
+        mocked_push_rebase_branch, mocked_create_pr,
+        init_test_repositories, fake_github_provider, tmpdir
+    ):
+        """With strict policy, upstream content loss causes failure."""
+        source, rebase, dest = init_test_repositories
+        mocked_is_pr_available.return_value = None, False
+        mocked_push_rebase_branch.return_value = True
+
+        CommitBuilder(source).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("set up base code")
+
+        CommitBuilder(dest).update_file(
+            "test.go", _ORIGINAL_CODE
+        ).commit("UPSTREAM: <carry>: sync base")
+
+        CommitBuilder(source).update_file(
+            "test.go", _UPSTREAM_ADDED_CODE
+        ).commit("Add KMS key support")
+
+        CommitBuilder(dest).update_file(
+            "test.go", _DOWNSTREAM_CARRY_CODE
+        ).commit("UPSTREAM: <carry>: add snapshot timeout")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.conflict_policy = "strict"
+        args.bot_emails = []
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.ignore_manual_label = False
+        args.dry_run = True
+
+        result = cli.rebasebot_run(
+            args, slack_webhook=None,
+            github_app_wrapper=fake_github_provider)
+        # Should fail — upstream content was lost
+        assert result is False
+
+    @patch("rebasebot.bot._create_pr")
+    @patch("rebasebot.bot._push_rebase_branch")
+    @patch("rebasebot.bot._is_pr_available")
+    @patch("rebasebot.bot._message_slack")
+    def test_strict_policy_succeeds_when_no_conflict(
+        self, mocked_message_slack, mocked_is_pr_available,
+        mocked_push_rebase_branch, mocked_create_pr,
+        init_test_repositories, fake_github_provider, tmpdir
+    ):
+        """With strict policy, clean cherry-picks succeed (no false positives)."""
+        source, rebase, dest = init_test_repositories
+        mocked_is_pr_available.return_value = None, False
+        mocked_push_rebase_branch.return_value = True
+
+        # Source adds an unrelated new file
+        CommitBuilder(source).add_file(
+            "new_upstream_file.go",
+            "package main\nfunc upstream() {}\n"
+        ).commit("Add new upstream file")
+
+        # Dest adds a different unrelated file (no conflict)
+        CommitBuilder(dest).add_file(
+            "downstream_only.go",
+            "package main\nfunc downstream() {}\n"
+        ).commit("UPSTREAM: <carry>: downstream only file")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.conflict_policy = "strict"
+        args.bot_emails = []
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.ignore_manual_label = False
+        args.dry_run = True
+
+        result = cli.rebasebot_run(
+            args, slack_webhook=None,
+            github_app_wrapper=fake_github_provider)
+        # Should succeed — no conflict, no content loss
+        assert result is True

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -115,6 +115,7 @@ class TestRebases:
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = True
         result = cli.rebasebot_run(
@@ -168,6 +169,7 @@ class TestRebases:
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = True
         result = cli.rebasebot_run(
@@ -235,6 +237,7 @@ class TestRebases:
         args.bot_emails = [],
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = True
         result = cli.rebasebot_run(
@@ -303,6 +306,7 @@ class TestRebases:
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = True
 
@@ -353,6 +357,7 @@ class TestRebases:
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = False
 
@@ -414,6 +419,7 @@ class TestRebases:
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.ignore_manual_label = False
         args.dry_run = False
         result = cli.rebasebot_run(
@@ -452,6 +458,7 @@ class TestRebases:
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = [drop_commit.hexsha]
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
         result = cli.rebasebot_run(
             args, slack_webhook=None, github_app_wrapper=fake_github_provider)
@@ -506,6 +513,7 @@ git commit -m 'UPSTREAM: <drop>: test-hook-script generated files'
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
         args.post_rebase_hook = ["git:https://github.com/openshift-eng/rebasebot/main:tests/data/test-hook-script.sh"]  # noqa: E501
 
@@ -564,6 +572,7 @@ git commit -m 'UPSTREAM: <drop>: test-hook-script generated files'
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True,
         args.post_rebase_hook = [f"git:dest/{dest.branch}:test-hook-script.sh"]
         args.source_repo = None
@@ -619,6 +628,7 @@ exit 5""")
         args.bot_emails = ["genbot@example.com", "anotherbot@example.com"]
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
 
         result = cli.rebasebot_run(
@@ -671,6 +681,7 @@ echo main
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
 
         result = cli.rebasebot_run(
@@ -709,6 +720,7 @@ touch post-rebase-hook.success"""
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
         args.ignore_manual_label = True
         args.always_run_hooks = True
@@ -760,6 +772,7 @@ touch post-rebase-hook.success"""
         args.bot_emails = []
         args.exclude_commits = []
         args.update_go_modules = False
+        args.conflict_policy = "auto"
         args.dry_run = True
         args.ignore_manual_label = True
         args.always_run_hooks = False  # Key difference: hooks should NOT run


### PR DESCRIPTION
  When cherry-picking downstream carry patches, -Xtheirs silently resolves
  content conflicts by favoring the downstream version, which can drop
  upstream additions without any warning.

  Add a new --conflict-policy flag with three modes:
  - auto: no detection (default, preserves existing behavior)
  - warn: log warnings when upstream content may have been lost
  - strict: fail when upstream content is lost

  The detection compares each cherry-picked file against the upstream
  version to find missing lines after -Xtheirs resolution.

Fixes #77