### PR TITLE
NO-JIRA: Fix (iss) must be a string type error

### DIFF
--- a/rebasebot/github.py
+++ b/rebasebot/github.py
@@ -179,7 +179,8 @@ class GithubAppProvider:
     def _github_login_app(credentials: GitHubAppCredentials) -> github3.GitHub:
         logging.info("Logging to GitHub as an Application for repository %s", credentials.github_branch.url)
         gh_app = github3.GitHub()
-        gh_app.login_as_app(credentials.app_key, credentials.app_id, expire_in=300)
+        app_id = str(credentials.app_id)
+        gh_app.login_as_app(credentials.app_key, app_id, expire_in=300)
         gh_branch = credentials.github_branch
 
         try:
@@ -191,7 +192,7 @@ class GithubAppProvider:
             logging.error(msg)
             raise builtins.Exception(msg) from err
 
-        gh_app.login_as_app_installation(credentials.app_key, credentials.app_id, install.id)
+        gh_app.login_as_app_installation(credentials.app_key, app_id, install.id)
         return gh_app
 
     def _get_github_user_logged_in_app(self) -> github3.GitHub:


### PR DESCRIPTION
This is a regression of https://github.com/openshift-eng/rebasebot/pull/76. During the tooling overhaul the jwt library version was bumped causing the issue to regress.

This commit is quick fix to unblock rebasees. Casting the variable from int to str to pass the check. 

I'll implement these changes to avoid similar regressions.
1. Create E2E presubmit job that runs a full rebase with GitHub operations.
2. Switch to better maintained PyGithub library #71 
3. Setup type checker. Either https://github.com/astral-sh/ty (if it is ready) or Pyright.

