### PR TITLE
fix: reset rebase branch to dest when --always-run-hooks and no rebase

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -1062,7 +1062,14 @@ def run(
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.POST_REBASE)
             _cherrypick_art_pull_request(gitwd, dest_repo, dest, conflict_policy)
         elif always_run_hooks:
-            # Run hooks without rebase operations when --always-run-hooks is enabled
+            # When no rebase is needed but hooks should still run,
+            # reset the rebase branch to dest (which already contains source)
+            # so that hooks run on top of all downstream carry commits.
+            # Without this, hooks would run on top of the source branch,
+            # producing a rebase branch that is missing all carry commits
+            # and causing merge conflicts when creating a PR.
+            logging.info("No rebase needed, but --always-run-hooks is set. Running hooks on top of dest branch.")
+            gitwd.git.reset("--hard", f"dest/{dest.branch}")
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.PRE_REBASE)
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.PRE_CARRY_COMMIT)
             hooks.execute_scripts_for_hook(hook=lifecycle_hooks.LifecycleHook.POST_REBASE)

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -787,3 +787,64 @@ touch post-rebase-hook.success"""
         # Verify hooks were NOT executed - marker files should not exist
         assert "pre-rebase-hook.success" not in os.listdir(tmpdir)
         assert "post-rebase-hook.success" not in os.listdir(tmpdir)
+
+    def test_always_run_hooks_preserves_carry_commits(self, init_test_repositories, fake_github_provider, tmpdir):
+        """Test that hooks run on top of dest branch (not source) when no rebase is needed.
+
+        This verifies the fix for a bug where --always-run-hooks would run hooks
+        on top of the source/upstream branch, producing a rebase branch missing
+        all downstream carry commits. The resulting PR would have merge conflicts
+        because it tried to merge a branch without carries into dest which has them.
+        """
+        source, rebase, dest = init_test_repositories
+
+        # Add a carry commit with a downstream-only file to dest
+        with CommitBuilder(dest) as cb:
+            cb.add_file("DOWNSTREAM_OWNERS", "approvers:\n- testuser\n")
+            cb.commit("UPSTREAM: <carry>: add DOWNSTREAM_OWNERS")
+
+        # Hook that verifies DOWNSTREAM_OWNERS exists (i.e. we're on dest, not source)
+        # and creates a marker file to prove it ran on the right branch
+        post_rebase_hook_script = """#!/bin/bash
+if [ -f DOWNSTREAM_OWNERS ]; then
+    echo "carry-preserved" > hook-verified-carry.txt
+    git add hook-verified-carry.txt
+    git commit -m "UPSTREAM: <drop>: hook verified carry commits present"
+else
+    echo "FAIL: DOWNSTREAM_OWNERS not found - hooks ran on source, not dest" >&2
+    exit 1
+fi"""
+
+        with CommitBuilder(dest) as cb:
+            cb.add_file("verify-hook.sh", post_rebase_hook_script)
+            cb.commit("UPSTREAM: <carry>: add verify hook script")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "none"
+        args.bot_emails = []
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.conflict_policy = "auto"
+        args.dry_run = True
+        args.ignore_manual_label = True
+        args.always_run_hooks = True
+
+        args.pre_rebase_hook = None
+        args.post_rebase_hook = [f"git:dest/{dest.branch}:verify-hook.sh"]
+        args.pre_carry_commit_hook = None
+        args.pre_push_rebase_branch_hook = None
+        args.pre_create_pr_hook = None
+
+        result = cli.rebasebot_run(args, slack_webhook=None, github_app_wrapper=fake_github_provider)
+
+        assert result is True
+        # The hook should have succeeded (exit 0), proving DOWNSTREAM_OWNERS existed
+        # which means hooks ran on dest branch, not source branch
+        assert "hook-verified-carry.txt" in os.listdir(tmpdir)


### PR DESCRIPTION
When _needs_rebase() returns False and --always-run-hooks is True, hooks were running on top of the source/upstream branch because _init_working_dir() always checks out the rebase branch pointing at source. This produced a rebase branch missing all downstream carry commits, causing merge conflicts in the resulting PR.

Fix by resetting the rebase branch to dest/{branch} before running hooks in the always_run_hooks path. Since dest already contains source (verified by _needs_rebase), this preserves all carry commits and hooks apply their changes on top of the current downstream state.

The needs_rebase=True path is completely untouched.