### PR TITLE
OCPCLOUD-3538: Add podman and docker symlink to container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,8 @@ ARG TARGETARCH=amd64
 ARG GO_VERSION=1.25.9
 
 # The Go project uses "arm64" instead of "aarch64" in filenames
-RUN dnf install -y tar gzip gpgme gpgme-devel pkgconfig jq && \
+RUN dnf install -y tar gzip gpgme gpgme-devel pkgconfig jq podman && \
+    ln -s /usr/bin/podman /usr/bin/docker && \
     ARCH=$(case "${TARGETARCH:-amd64}" in aarch64) echo "arm64" ;; amd64) echo "amd64" ;; *) echo "${TARGETARCH:-amd64}" ;; esac) && \
     curl -fLsS -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" && \
     tar -C /usr/local -xzf /tmp/go.tar.gz && \


### PR DESCRIPTION
## Summary
- Adds `podman` to the container image packages
- Creates a `/usr/bin/docker` -> `/usr/bin/podman` symlink

Adding podman and a docker symlink allows hooks that want to leverage tooling not available in the rebasebot image to leverage containers to fetch and run tooling on demand in CI environments.

Related: [OCPCLOUD-3538](https://redhat.atlassian.net/browse/OCPCLOUD-3538)

## Test plan
- [ ] Verify rebasebot image builds successfully with podman installed
- [ ] Verify `docker` symlink resolves to podman in the built image