### PR TITLE
fix: normalize bot email matching and preserve squash author

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -404,7 +404,7 @@ def _check_upstream_content_loss(gitwd: git.Repo, source_branch: str, only_files
 
 def _safe_cherry_pick(
     gitwd: git.Repo, sha: str, source_branch: str, conflict_policy: str, commit_description: str
-) -> None:
+) -> bool:
     """
     Cherry-pick a commit with conflict detection based on conflict_policy.
 
@@ -412,7 +412,11 @@ def _safe_cherry_pick(
     For "warn"/"strict" policies: first probes for conflicts without
     -Xtheirs, then cherry-picks with -Xtheirs, then verifies only the
     files that actually conflicted for upstream content loss.
+
+    Returns True when the cherry-pick creates a commit and False when it is skipped as empty.
     """
+    start_head = gitwd.head.commit.hexsha
+
     # Phase 1: probe for conflicts (only for warn/strict)
     conflicted_files = set()
     if conflict_policy != "auto":
@@ -427,12 +431,12 @@ def _safe_cherry_pick(
 
     # If no conflicts were detected, -Xtheirs had no effect — skip check
     if conflict_policy == "auto" or not conflicted_files:
-        return
+        return gitwd.head.commit.hexsha != start_head
 
     # Only verify files that had actual merge conflicts
     lost_content = _check_upstream_content_loss(gitwd, source_branch, conflicted_files)
     if not lost_content:
-        return
+        return gitwd.head.commit.hexsha != start_head
 
     for filename, lost_lines in lost_content:
         logging.warning(
@@ -451,6 +455,8 @@ def _safe_cherry_pick(
             f"-Xtheirs resolved a content conflict by dropping "
             f"upstream additions. Manual resolution is required."
         )
+
+    return gitwd.head.commit.hexsha != start_head
 
 
 def _do_rebase(
@@ -517,21 +523,30 @@ def _do_rebase(
     if allow_bot_squash:
         for key, value in commits_to_squash.items():
             logging.info("Squashing commits for bot: %s: %s", key, value)
+            created_commit_count = 0
+            newest_created_commit = None
             for commit in value:
-                _safe_cherry_pick(
+                if _safe_cherry_pick(
                     gitwd=gitwd,
                     sha=commit["sha"],
                     source_branch=source.branch,
                     conflict_policy=conflict_policy,
                     commit_description=f"{commit['sha']} - {commit['commit_message']}",
-                )
+                ):
+                    created_commit_count += 1
+                    newest_created_commit = commit
+
+            if newest_created_commit is None:
+                logging.info("Skipping squashed bot commit for %s because all picks were empty.", key)
+                continue
+
             # Capture author before reset makes the cherry-picked commits unreachable.
             last_author = gitwd.head.commit.author
             author_string = f"{last_author.name} <{last_author.email}>"
 
-            gitwd.git.reset("--soft", f"HEAD~{len(value)}")
+            gitwd.git.reset("--soft", f"HEAD~{created_commit_count}")
 
-            newest_bot_commit_message = value[-1]["commit_message"]
+            newest_bot_commit_message = newest_created_commit["commit_message"]
 
             gitwd.git.commit("-m", newest_bot_commit_message, "--author", author_string)
 

--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -142,6 +142,19 @@ def _in_excluded_commits(sha: str, exclude_commits: list) -> bool:
     return False
 
 
+def _normalize_bot_email(email: str) -> str:
+    """Normalize GitHub noreply addresses without collapsing real plus-addresses."""
+    local, sep, domain = email.partition("@")
+    if not sep:
+        return email
+
+    prefix, plus, rest = local.partition("+")
+    if plus and prefix.isdigit() and rest:
+        return f"{rest}@{domain}"
+
+    return email
+
+
 def _find_last_rebase_merge_commit(gitwd: git.Repo, ancestry_path_merges) -> Commit:
     logging.info("Searching for merge commit from previous rebasebot run to identify downstream commits")
     for merge_line in ancestry_path_merges:
@@ -455,6 +468,7 @@ def _do_rebase(
     logging.info("Performing rebase")
 
     allow_bot_squash = len(bot_emails) > 0
+    normalized_bot_emails = {_normalize_bot_email(email) for email in bot_emails}
     if allow_bot_squash:
         logging.info("Bot squashing is enabled.")
 
@@ -483,11 +497,8 @@ def _do_rebase(
             continue
 
         if allow_bot_squash:
-            # There is sometimes a prefix with number and a following + sign
-            # We have to get rid of that part to make sure to get
-            # only the email of the bot.
-            email = committer_email.split("+")[-1]
-            if email in bot_emails:
+            email = _normalize_bot_email(committer_email)
+            if email in normalized_bot_emails:
                 commits_to_squash[email].append({"sha": sha, "commit_message": commit_message})
                 continue
 
@@ -514,11 +525,15 @@ def _do_rebase(
                     conflict_policy=conflict_policy,
                     commit_description=f"{commit['sha']} - {commit['commit_message']}",
                 )
+            # Capture author before reset makes the cherry-picked commits unreachable.
+            last_author = gitwd.head.commit.author
+            author_string = f"{last_author.name} <{last_author.email}>"
+
             gitwd.git.reset("--soft", f"HEAD~{len(value)}")
 
             newest_bot_commit_message = value[-1]["commit_message"]
 
-            gitwd.git.commit("-m", newest_bot_commit_message, "--author", key)
+            gitwd.git.commit("-m", newest_bot_commit_message, "--author", author_string)
 
 
 def _prepare_rebase_branch(gitwd: git.Repo, source: GitHubBranch, dest: GitHubBranch) -> None:

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -184,6 +184,68 @@ class TestRebases:
 """.strip()  # noqa: W291
         )
 
+    def test_squash_bot_email_normalization(self, init_test_repositories, fake_github_provider, tmpdir):
+        """GitHub noreply numeric prefixes should normalize without collapsing real plus-addresses."""
+        source, rebase, dest = init_test_repositories
+        with CommitBuilder(source) as cb:
+            cb.add_file("baz.txt", "fiz")
+            cb.commit("other upstream commit")
+        with CommitBuilder(dest) as cb:
+            cb.add_file("generated-test-genbot", "content")
+            cb.commit("commit #1 from genbot", committer_email="12345+genbot@example.com")
+        with CommitBuilder(dest) as cb:
+            cb.add_file("generated-test-genbot-2", "content")
+            cb.commit("commit #2 from genbot", committer_email="12345+genbot@example.com")
+        with CommitBuilder(dest) as cb:
+            cb.add_file("generated-test-ci", "content")
+            cb.commit("commit #1 from ci nightly", committer_email="ci+nightly@example.com")
+        with CommitBuilder(dest) as cb:
+            cb.add_file("generated-test-ops", "content")
+            cb.commit("commit #1 from ops nightly", committer_email="ops+nightly@example.com")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.bot_emails = ["12345+genbot@example.com", "ci+nightly@example.com", "ops+nightly@example.com"]
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.conflict_policy = "auto"
+        args.ignore_manual_label = False
+        args.dry_run = True
+        result = cli.rebasebot_run(args, slack_webhook=None, github_app_wrapper=fake_github_provider)
+        assert result
+
+        working_repo = Repo.init(tmpdir)
+        assert working_repo.head.ref.name == "rebase"
+        log_graph = working_repo.git.log("--graph", "--oneline", "--pretty='<%an>, %s'")
+        assert "* '<dest_ops+nightly@example.com>, commit #1 from ops nightly'" in log_graph
+        assert "* '<dest_ci+nightly@example.com>, commit #1 from ci nightly'" in log_graph
+        assert (
+            log_graph
+            == r"""
+* '<dest_ops+nightly@example.com>, commit #1 from ops nightly'
+* '<dest_ci+nightly@example.com>, commit #1 from ci nightly'
+* '<dest_12345+genbot@example.com>, commit #2 from genbot'
+* '<dest_author>, UPSTREAM: <carry>: our cool addition'
+*   '<test_rebasebot>, merge upstream/main into main'
+|\  
+| * '<source_author>, other upstream commit'
+* | '<dest_ops+nightly@example.com>, commit #1 from ops nightly'
+* | '<dest_ci+nightly@example.com>, commit #1 from ci nightly'
+* | '<dest_12345+genbot@example.com>, commit #2 from genbot'
+* | '<dest_12345+genbot@example.com>, commit #1 from genbot'
+* | '<dest_author>, UPSTREAM: <carry>: our cool addition'
+|/  
+* '<source_author>, Upstream commit'
+""".strip()  # noqa: W291
+        )
+
     def test_first_run_dest_has_merges_dry_run(self, init_test_repositories, fake_github_provider, tmpdir):
         source, rebase, dest = init_test_repositories
         with CommitBuilder(source) as cb:

--- a/tests/test_rebases.py
+++ b/tests/test_rebases.py
@@ -246,6 +246,61 @@ class TestRebases:
 """.strip()  # noqa: W291
         )
 
+    def test_squash_bot_skips_empty_later_pick(self, init_test_repositories, fake_github_provider, tmpdir):
+        """A later empty bot pick must not rewind past earlier squashed bot commits."""
+        source, rebase, dest = init_test_repositories
+        with CommitBuilder(source) as cb:
+            cb.add_file("baz.txt", "fiz")
+            cb.commit("other upstream commit")
+        with CommitBuilder(dest) as cb:
+            cb.add_file("generated-test", "content from first bot")
+            cb.commit("commit #1 from firstbot", committer_email="firstbot@example.com")
+        with CommitBuilder(dest) as cb:
+            cb.update_file("generated-test", "content from second bot")
+            cb.commit("commit #1 from secondbot", committer_email="secondbot@example.com")
+        with CommitBuilder(dest) as cb:
+            cb.update_file("generated-test", "content from second bot")
+            cb.commit("commit #2 from secondbot", committer_email="secondbot@example.com")
+
+        args = MagicMock()
+        args.source = source
+        args.source_repo = None
+        args.dest = dest
+        args.rebase = rebase
+        args.working_dir = tmpdir
+        args.git_username = "test_rebasebot"
+        args.git_email = "test@rebasebot.ocp"
+        args.tag_policy = "soft"
+        args.bot_emails = ["firstbot@example.com", "secondbot@example.com"]
+        args.exclude_commits = []
+        args.update_go_modules = False
+        args.conflict_policy = "auto"
+        args.ignore_manual_label = False
+        args.dry_run = True
+        result = cli.rebasebot_run(args, slack_webhook=None, github_app_wrapper=fake_github_provider)
+        assert result
+
+        working_repo = Repo.init(tmpdir)
+        assert working_repo.head.ref.name == "rebase"
+        log_graph = working_repo.git.log("--graph", "--oneline", "--pretty='<%an>, %s'")
+        assert (
+            log_graph
+            == r"""
+* '<dest_secondbot@example.com>, commit #1 from secondbot'
+* '<dest_firstbot@example.com>, commit #1 from firstbot'
+* '<dest_author>, UPSTREAM: <carry>: our cool addition'
+*   '<test_rebasebot>, merge upstream/main into main'
+|\  
+| * '<source_author>, other upstream commit'
+* | '<dest_secondbot@example.com>, commit #2 from secondbot'
+* | '<dest_secondbot@example.com>, commit #1 from secondbot'
+* | '<dest_firstbot@example.com>, commit #1 from firstbot'
+* | '<dest_author>, UPSTREAM: <carry>: our cool addition'
+|/  
+* '<source_author>, Upstream commit'
+""".strip()  # noqa: W291
+        )
+
     def test_first_run_dest_has_merges_dry_run(self, init_test_repositories, fake_github_provider, tmpdir):
         source, rebase, dest = init_test_repositories
         with CommitBuilder(source) as cb:


### PR DESCRIPTION
## Summary
- normalize bot email matching so GitHub noreply-style addresses like `12345+bot@example.com` still match `--bot-emails`
- keep real plus-addressed emails distinct instead of collapsing them into one bot identity
- preserve the original author when squashing bot commits
- add a regression test covering both email normalization cases

## Why
Rebasebot normalized bot emails from commits differently than emails passed in `--bot-emails`, which could prevent expected bot commit squashing. This change makes matching consistent while avoiding false matches for real plus-addressed emails.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of bot-generated commits by normalizing GitHub noreply-style committer emails, while preserving legitimate `+tag` addressing.
  * Enhanced bot-commit squashing to correctly attribute the resulting squashed commit to the intended author, even when intermediate cherry-picks are empty.
* **Tests**
  * Added a regression test covering numeric `+` committer email forms during bot squashing, verifying commit attribution and the expected rebase graph structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->