### PR TITLE
Replace CLAUDE.md symlink with @AGENTS.md import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
Cursor reads both CLAUDE.md and AGENTS.md. Since CLAUDE.md was a symlink to AGENTS.md, Cursor ended up reading the same content twice. This replaces the symlink with a plain CLAUDE.md containing an `@AGENTS.md` import, which Claude Code resolves the same way but avoids the double read in Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance by removing a reference to `AGENTS.md` from the shared instructions document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->